### PR TITLE
OTA enhancement. Split port and uploadPort in arduino.json

### DIFF
--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -104,7 +104,7 @@ export class ArduinoApp {
             await this.getMainSketch(dc);
         }
         if (!dc.uploadPort) {
-            vscode.window.showErrorMessage("Please specify the upload serial port.");
+            vscode.window.showErrorMessage("Please specify the upload port.");
             return;
         }
 

--- a/src/deviceContext.ts
+++ b/src/deviceContext.ts
@@ -22,6 +22,12 @@ export interface IDeviceContext {
     port: string;
 
     /**
+     * Upload Port. Defaults to COM port. It can be an IP address.
+     * @property {string}
+     */
+    uploadPort: string;
+
+    /**
      * Current selected Arduino board alias.
      * @property {string}
      */
@@ -66,6 +72,8 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
     private _onDidChange = new vscode.EventEmitter<void>();
 
     private _port: string;
+
+    private _uploadPort: string;
 
     private _board: string;
 
@@ -130,6 +138,7 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
                     deviceConfigJson = util.tryParseJSON(fs.readFileSync(configFile.fsPath, "utf8"));
                     if (deviceConfigJson) {
                         this._port = deviceConfigJson.port;
+                        this._uploadPort = deviceConfigJson.uploadPort;
                         this._board = deviceConfigJson.board;
                         this._sketch = deviceConfigJson.sketch;
                         this._configuration = deviceConfigJson.configuration;
@@ -141,6 +150,7 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
                     }
                 } else {
                     this._port = null;
+                    this._uploadPort = null;
                     this._board = null;
                     this._sketch = null;
                     this._configuration = null;
@@ -167,6 +177,7 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
         }
         deviceConfigJson.sketch = this.sketch;
         deviceConfigJson.port = this.port;
+        deviceConfigJson.uploadPort = this.uploadPort;
         deviceConfigJson.board = this.board;
         deviceConfigJson.output = this.output;
         deviceConfigJson["debugger"] = this.debugger_;
@@ -191,6 +202,15 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
 
     public set port(value: string) {
         this._port = value;
+        this.saveContext();
+    }
+
+    public get uploadPort() {
+        return this._uploadPort || this.port;
+    }
+
+    public set uploadPort(value: string) {
+        this._uploadPort = value;
         this.saveContext();
     }
 

--- a/src/deviceContext.ts
+++ b/src/deviceContext.ts
@@ -22,7 +22,9 @@ export interface IDeviceContext {
     port: string;
 
     /**
-     * Upload Port. Defaults to COM port. It can be an IP address.
+     * Port used for uploading the skecth. 
+     * It can be a COM port or an IP address (OTA)
+     * If undefined, it uses port value.
      * @property {string}
      */
     uploadPort: string;

--- a/src/deviceContext.ts
+++ b/src/deviceContext.ts
@@ -138,7 +138,7 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
                     deviceConfigJson = util.tryParseJSON(fs.readFileSync(configFile.fsPath, "utf8"));
                     if (deviceConfigJson) {
                         this._port = deviceConfigJson.port;
-                        this._uploadPort = deviceConfigJson.uploadPort;
+                        this._uploadPort = deviceConfigJson.uploadPort || deviceConfigJson.port;
                         this._board = deviceConfigJson.board;
                         this._sketch = deviceConfigJson.sketch;
                         this._configuration = deviceConfigJson.configuration;
@@ -206,7 +206,7 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
     }
 
     public get uploadPort() {
-        return this._uploadPort || this.port;
+        return this._uploadPort;
     }
 
     public set uploadPort(value: string) {

--- a/test/devicecontext.test.ts
+++ b/test/devicecontext.test.ts
@@ -13,6 +13,7 @@ suite("Arduino: Device Context config", () => {
             deviceContext.loadContext().then(() => {
                 assert.equal(deviceContext.board, "arduino:avr:diecimila");
                 assert.equal(deviceContext.port, "COM4");
+                assert.equal(deviceContext.uploadPort, "COM4");
                 assert.equal(deviceContext.sketch, "blink.ino");
                 assert.equal(deviceContext.configuration, "cpu=atmega328");
                 assert.equal(deviceContext.output, null);


### PR DESCRIPTION
This PR adds a new (optional) property in arduino.json, uploadPort. If defined, the user can specify an IP address or another COM port without closing the serial monitor. If not defined, uploadPort will default to port value, keeping the existing functionality.

Features:
- When uploadPort is specified, this port is used for uploading the sketch.
- When uploadPort is not defined, it uses the value specified in port.
- If uploadPort and port are different, the serial monitor is not closed nor reopened. 
- If uploadPort is the same as port, it keeps functionality. It checks the serial monitor usage. In case of being used, it shuts it down and reopens it after the upload.
- uploadPort can be either another serial port or an IP address.

Possible improvements:
- Document functionality in README.md
- Create a VSCode command