### PR TITLE
win32 platform support not utf8 encoding at childProcess.spawn() stdout/stderr

### DIFF
--- a/package.json
+++ b/package.json
@@ -532,6 +532,7 @@
     "eventemitter2": "^4.1.0",
     "express": "^4.14.1",
     "glob": "^7.1.1",
+    "iconv-lite": "^0.4.18",
     "properties": "^1.2.1",
     "uuid": "^3.0.1",
     "vscode-extension-telemetry": "0.0.6",

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -8,6 +8,7 @@ import * as path from "path";
 import * as properties from "properties";
 import * as vscode from "vscode";
 import * as WinReg from "winreg";
+import * as iconv from "iconv-lite";
 
 /**
  * This function will return the VSCode C/C++ extesnion compatible platform literals.
@@ -203,9 +204,38 @@ export function spawn(command: string, outputChannel: vscode.OutputChannel, args
         options.cwd = options.cwd || path.resolve(path.join(__dirname, ".."));
         const child = childProcess.spawn(command, args, options);
 
+        let codepage = "65001";
+        if (os.platform() === "win32") {
+            codepage = childProcess.execSync('chcp').toString().split(':').pop().trim();
+        }
+
         if (outputChannel) {
-            child.stdout.on("data", (data) => { outputChannel.append(data.toString()); });
-            child.stderr.on("data", (data) => { outputChannel.append(data.toString()); });
+            child.stdout.on("data", (data: Buffer) => {
+                switch (codepage) {
+                    case "932":
+                        outputChannel.append(iconv.decode(data, "Shift_JIS"));
+                        break;
+                    case "936":
+                        outputChannel.append(iconv.decode(data, "GBK"));
+                        break;
+                    default:
+                        outputChannel.append(data.toString());
+                        break;
+                }
+            });
+            child.stderr.on("data", (data: Buffer) => {
+                switch (codepage) {
+                    case "932":
+                        outputChannel.append(iconv.decode(data, "Shift_JIS"));
+                        break;
+                    case "936":
+                        outputChannel.append(iconv.decode(data, "GBK"));
+                        break;
+                    default:
+                        outputChannel.append(data.toString());
+                        break;
+                }
+            });
         }
 
         child.on("error", (error) => reject({ error, stderr, stdout }));

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -3,12 +3,12 @@
 
 import * as childProcess from "child_process";
 import * as fs from "fs";
+import * as iconv from "iconv-lite";
 import * as os from "os";
 import * as path from "path";
 import * as properties from "properties";
 import * as vscode from "vscode";
 import * as WinReg from "winreg";
-import * as iconv from "iconv-lite";
 
 /**
  * This function will return the VSCode C/C++ extesnion compatible platform literals.
@@ -206,7 +206,7 @@ export function spawn(command: string, outputChannel: vscode.OutputChannel, args
 
         let codepage = "65001";
         if (os.platform() === "win32") {
-            codepage = childProcess.execSync('chcp').toString().split(':').pop().trim();
+            codepage = childProcess.execSync("chcp").toString().split(":").pop().trim();
         }
 
         if (outputChannel) {


### PR DESCRIPTION
sorry about my poor English first..... m(_ _)m

When I use vscode-arduino at Chinese Windows system, output encoding is broken.

![image](https://user-images.githubusercontent.com/1682158/27992125-a812fd9a-64be-11e7-9e49-3399f5367c9f.png)

because Windows non-unicode app return by ansi.

so we can get ansi codepage, and use iconv-lite to decode it to utf8.