### PR TITLE
Pause UsbDetector during uploading

### DIFF
--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -20,6 +20,7 @@ import { VscodeSettings } from "./vscodeSettings";
 
 import { arduinoChannel } from "../common/outputChannel";
 import { SerialMonitor } from "../serialmonitor/serialMonitor";
+import { UsbDetector } from "../serialmonitor/usbDetector";
 
 /**
  * Represent an Arduino application based on the official Arduino IDE.
@@ -114,6 +115,7 @@ export class ArduinoApp {
         const serialMonitor = SerialMonitor.getInstance();
 
         const needRestore = await serialMonitor.closeSerialMonitor(dc.port);
+        UsbDetector.getInstance().pauseListening();
         await vscode.workspace.saveAll(false);
 
         const appPath = path.join(vscode.workspace.rootPath, dc.sketch);
@@ -122,6 +124,7 @@ export class ArduinoApp {
             args.push("--verbose");
         }
         await util.spawn(this._settings.commandPath, arduinoChannel.channel, args).then(async () => {
+            UsbDetector.getInstance().resumeListening();
             if (needRestore) {
                 await serialMonitor.openSerialMonitor();
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,6 @@ import * as Logger from "./logger/logger";
 import { SerialMonitor } from "./serialmonitor/serialMonitor";
 import { UsbDetector } from "./serialmonitor/usbDetector";
 
-let usbDetector: UsbDetector = null;
 const status: any = {};
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -184,8 +183,8 @@ export async function activate(context: vscode.ExtensionContext) {
     const completionProvider = new CompletionProvider();
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider(ARDUINO_MODE, completionProvider, "<", '"', "."));
 
-    usbDetector = new UsbDetector(context.extensionPath);
-    usbDetector.startListening();
+    UsbDetector.extensionRoot = context.extensionPath;
+    UsbDetector.getInstance().startListening();
 
     if (vscode.workspace.rootPath && (
         util.fileExistsSync(path.join(vscode.workspace.rootPath, ARDUINO_CONFIG_FILE))
@@ -222,8 +221,6 @@ export async function activate(context: vscode.ExtensionContext) {
 export async function deactivate() {
     const monitor = SerialMonitor.getInstance();
     await monitor.closeSerialMonitor(null, false);
-    if (usbDetector) {
-        usbDetector.stopListening();
-    }
+    UsbDetector.getInstance().stopListening();
     Logger.traceUserData("deactivate-extension");
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -183,7 +183,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const completionProvider = new CompletionProvider();
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider(ARDUINO_MODE, completionProvider, "<", '"', "."));
 
-    UsbDetector.extensionRoot = context.extensionPath;
+    UsbDetector.getInstance().initialize(context.extensionPath);
     UsbDetector.getInstance().startListening();
 
     if (vscode.workspace.rootPath && (

--- a/src/serialmonitor/usbDetector.ts
+++ b/src/serialmonitor/usbDetector.ts
@@ -14,11 +14,9 @@ import { SerialMonitor } from "./serialMonitor";
 
 export class UsbDetector {
 
-    public static extensionRoot: string;
-
     public static getInstance(): UsbDetector {
         if (!UsbDetector._instance) {
-            UsbDetector._instance = new UsbDetector(UsbDetector.extensionRoot);
+            UsbDetector._instance = new UsbDetector();
         }
         return UsbDetector._instance;
     }
@@ -29,8 +27,13 @@ export class UsbDetector {
 
     private _boardDescriptors = null;
 
-    private constructor(
-        private _extensionRoot: string) {
+    private _extensionRoot = null;
+
+    private constructor() {
+    }
+
+    public initialize(extensionRoot: string) {
+        this._extensionRoot = extensionRoot;
     }
 
     public async startListening() {
@@ -41,6 +44,10 @@ export class UsbDetector {
 
         if (!this._usbDetector) {
             return;
+        }
+
+        if (this._extensionRoot === null) {
+            throw new Error("UsbDetector should be initialized before using.");
         }
 
         this._usbDetector.on("add", async (device) => {

--- a/src/serialmonitor/usbDetector.ts
+++ b/src/serialmonitor/usbDetector.ts
@@ -14,11 +14,22 @@ import { SerialMonitor } from "./serialMonitor";
 
 export class UsbDetector {
 
+    public static extensionRoot: string;
+
+    public static getInstance(): UsbDetector {
+        if (!UsbDetector._instance) {
+            UsbDetector._instance = new UsbDetector(UsbDetector.extensionRoot);
+        }
+        return UsbDetector._instance;
+    }
+
+    private static _instance: UsbDetector;
+
     private _usbDetector;
 
     private _boardDescriptors = null;
 
-    constructor(
+    private constructor(
         private _extensionRoot: string) {
     }
 

--- a/src/serialmonitor/usbDetector.ts
+++ b/src/serialmonitor/usbDetector.ts
@@ -117,6 +117,20 @@ export class UsbDetector {
         }
     }
 
+    public pauseListening() {
+        if (this._usbDetector) {
+            this._usbDetector.stopMonitoring();
+        }
+    }
+
+    public resumeListening() {
+        if (this._usbDetector) {
+            this._usbDetector.startMonitoring();
+        } else {
+            this.startListening();
+        }
+    }
+
     private switchBoard(bd: IBoard, vid: string, pid: string) {
         ArduinoContext.boardManager.doChangeBoardType(bd);
         const monitor = SerialMonitor.getInstance();


### PR DESCRIPTION
Pause UsbDetector during uploading, so that the resetting of board during uploading will not trigger an annoying display of the board's README.
