### PR TITLE
Add more freedom on Mac with different version of Arduino

### DIFF
--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -56,11 +56,7 @@ export class ArduinoSettings implements IArduinoSettings {
 
     public get defaultExamplePath(): string {
         if (os.platform() === "darwin") {
-            if (this._arduinoPath.match(/Arduino.*\.app/)){
-                return path.join(this._arduinoPath, "/Contents/Java/examples");
-            }else{
-                return path.join(this._arduinoPath, "Arduino.app/Contents/Java/examples");
-            }
+            return path.join(util.resolveMacArduinoAppPath(this._arduinoPath), "/Contents/Java/examples");
         } else {
             return path.join(this._arduinoPath, "examples");
         }
@@ -72,11 +68,7 @@ export class ArduinoSettings implements IArduinoSettings {
 
     public get defaultPackagePath(): string {
         if (os.platform() === "darwin") {
-            if (this._arduinoPath.match(/Arduino.*\.app/)){
-                return path.join(this._arduinoPath, "/Contents/Java/hardware");
-            }else{
-                return path.join(this._arduinoPath, "Arduino.app/Contents/Java/hardware");
-            } 
+            return path.join(util.resolveMacArduinoAppPath(this._arduinoPath), "/Contents/Java/hardware");
         } else { // linux and win32.
             return path.join(this._arduinoPath, "hardware");
         }
@@ -84,11 +76,7 @@ export class ArduinoSettings implements IArduinoSettings {
 
     public get defaultLibPath(): string {
         if (os.platform() === "darwin") {
-            if (this._arduinoPath.match(/Arduino.*\.app/)){
-                return path.join(this._arduinoPath, "/Contents/Java/libraries");
-            }else{
-                return path.join(this._arduinoPath, "Arduino.app/Contents/Java/libraries");
-            }
+            return path.join(util.resolveMacArduinoAppPath(this._arduinoPath), "/Contents/Java/libraries");
         } else { // linux and win32
             return path.join(this._arduinoPath, "libraries");
         }
@@ -97,11 +85,7 @@ export class ArduinoSettings implements IArduinoSettings {
     public get commandPath(): string {
         const platform = os.platform();
         if (platform === "darwin") {
-            if (this._arduinoPath.match(/Arduino.*\.app/)){
-                return path.join(this._arduinoPath, path.normalize("/Contents/MacOS/Arduino"));
-            }else{
-                return path.join(this._arduinoPath, path.normalize("Arduino.app/Contents/MacOS/Arduino"));
-            }
+            return path.join(util.resolveMacArduinoAppPath(this._arduinoPath), path.normalize("/Contents/MacOS/Arduino"));
         } else if (platform === "linux") {
             return path.join(this._arduinoPath, "arduino");
         } else if (platform === "win32") {

--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -56,7 +56,11 @@ export class ArduinoSettings implements IArduinoSettings {
 
     public get defaultExamplePath(): string {
         if (os.platform() === "darwin") {
-            return path.join(this._arduinoPath, "Arduino.app/Contents/Java/examples");
+            if (this._arduinoPath.match(/Arduino.*\.app/)){
+                return path.join(this._arduinoPath, "/Contents/Java/examples");
+            }else{
+                return path.join(this._arduinoPath, "Arduino.app/Contents/Java/examples");
+            }
         } else {
             return path.join(this._arduinoPath, "examples");
         }
@@ -68,7 +72,11 @@ export class ArduinoSettings implements IArduinoSettings {
 
     public get defaultPackagePath(): string {
         if (os.platform() === "darwin") {
-            return path.join(this._arduinoPath, "Arduino.app/Contents/Java/hardware");
+            if (this._arduinoPath.match(/Arduino.*\.app/)){
+                return path.join(this._arduinoPath, "/Contents/Java/hardware");
+            }else{
+                return path.join(this._arduinoPath, "Arduino.app/Contents/Java/hardware");
+            } 
         } else { // linux and win32.
             return path.join(this._arduinoPath, "hardware");
         }
@@ -76,7 +84,11 @@ export class ArduinoSettings implements IArduinoSettings {
 
     public get defaultLibPath(): string {
         if (os.platform() === "darwin") {
-            return path.join(this._arduinoPath, "Arduino.app/Contents/Java/libraries");
+            if (this._arduinoPath.match(/Arduino.*\.app/)){
+                return path.join(this._arduinoPath, "/Contents/Java/libraries");
+            }else{
+                return path.join(this._arduinoPath, "Arduino.app/Contents/Java/libraries");
+            }
         } else { // linux and win32
             return path.join(this._arduinoPath, "libraries");
         }
@@ -85,7 +97,11 @@ export class ArduinoSettings implements IArduinoSettings {
     public get commandPath(): string {
         const platform = os.platform();
         if (platform === "darwin") {
-            return path.join(this._arduinoPath, path.normalize("Arduino.app/Contents/MacOS/Arduino"));
+            if (this._arduinoPath.match(/Arduino.*\.app/)){
+                return path.join(this._arduinoPath, path.normalize("/Contents/MacOS/Arduino"));
+            }else{
+                return path.join(this._arduinoPath, path.normalize("Arduino.app/Contents/MacOS/Arduino"));
+            }
         } else if (platform === "linux") {
             return path.join(this._arduinoPath, "arduino");
         } else if (platform === "win32") {

--- a/src/common/sys/darwin.ts
+++ b/src/common/sys/darwin.ts
@@ -19,7 +19,11 @@ export function resolveArduinoPath(): string {
 }
 
 export function validateArduinoPath(arduinoPath: string): boolean {
-    return fileExistsSync(path.join(arduinoPath, "Arduino.app/Contents/MacOS/Arduino"));
+    if (arduinoPath.match(/Arduino.*\.app/)){
+        return fileExistsSync(path.join(arduinoPath, "/Contents/MacOS/Arduino"));
+    }else{
+        return fileExistsSync(path.join(arduinoPath, "Arduino.app/Contents/MacOS/Arduino"));
+    }
 }
 
 export function findFile(fileName: string, cwd: string): string {

--- a/src/common/sys/darwin.ts
+++ b/src/common/sys/darwin.ts
@@ -3,7 +3,7 @@
 
 import * as childProcess from "child_process";
 import * as path from "path";
-import { directoryExistsSync, fileExistsSync } from "../util";
+import { directoryExistsSync, fileExistsSync, resolveMacArduinoAppPath } from "../util";
 
 export function resolveArduinoPath(): string {
     let result;
@@ -19,11 +19,7 @@ export function resolveArduinoPath(): string {
 }
 
 export function validateArduinoPath(arduinoPath: string): boolean {
-    if (arduinoPath.match(/Arduino.*\.app/)){
-        return fileExistsSync(path.join(arduinoPath, "/Contents/MacOS/Arduino"));
-    }else{
-        return fileExistsSync(path.join(arduinoPath, "Arduino.app/Contents/MacOS/Arduino"));
-    }
+    return fileExistsSync(path.join(resolveMacArduinoAppPath(arduinoPath), "/Contents/MacOS/Arduino"));
 }
 
 export function findFile(fileName: string, cwd: string): string {

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -388,3 +388,16 @@ export function getRegistryValues(hive: string, key: string, name: string): Prom
 export function convertToHex(number, width = 0) {
     return padStart(number.toString(16), width, "0");
 }
+
+/**
+ * This will accept any Arduino*.app on Mac OS,
+ * in case you named Arduino with a version number
+ * @argument {string} arduinoPath
+ */
+export function resolveMacArduinoAppPath(arduinoPath: string): string {
+    if (/Arduino.*\.app/.test(arduinoPath)) {
+        return arduinoPath;
+    } else {
+        return path.join(arduinoPath, "Arduino.app");
+    }
+}


### PR DESCRIPTION
On Mac Arduino app has to be called "Arduino.app". In some cases (include me) we add a version number to keep a bunch of Arduino due to compatibility issues.
This PR add a regex check when generating a path. If it already specify a Arduino app, no "Arduino.app" is added. 
