### PR TITLE
Add board support for STM32F1 with Arduino_STM32

### DIFF
--- a/misc/usbmapping.json
+++ b/misc/usbmapping.json
@@ -143,5 +143,57 @@
         "target": "stm32f4x.cfg"
       }
     ]
+  },
+  {
+    "boards": [
+      {
+        "name": "genericSTM32F103C",
+        "package": "Arduino_STM32",
+        "architecture": "STM32F1",
+        "id": "genericSTM32F103C",
+        "interface": "stlink-v2.cfg",
+        "target": "stm32f1x.cfg"
+      },
+      {
+        "name": "genericSTM32F103R",
+        "package": "Arduino_STM32",
+        "architecture": "STM32F1",
+        "id": "genericSTM32F103R",
+        "interface": "stlink-v2.cfg",
+        "target": "stm32f1x.cfg"
+      },
+      {
+        "name": "genericSTM32F103T",
+        "package": "Arduino_STM32",
+        "architecture": "STM32F1",
+        "id": "genericSTM32F103T",
+        "interface": "stlink-v2.cfg",
+        "target": "stm32f1x.cfg"
+      },
+      {
+        "name": "genericSTM32F103V",
+        "package": "Arduino_STM32",
+        "architecture": "STM32F1",
+        "id": "genericSTM32F103V",
+        "interface": "stlink-v2.cfg",
+        "target": "stm32f1x.cfg"
+      },
+      {
+        "name": "genericSTM32F103Z",
+        "package": "Arduino_STM32",
+        "architecture": "STM32F1",
+        "id": "genericSTM32F103Z",
+        "interface": "stlink-v2.cfg",
+        "target": "stm32f1x.cfg"
+      },
+      {
+        "name": "genericGD32F103C",
+        "package": "Arduino_STM32",
+        "architecture": "STM32F1",
+        "id": "genericGD32F103C",
+        "interface": "stlink-v2.cfg",
+        "target": "stm32f1x.cfg"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This is an addition for debugging STM32F1 series with

https://github.com/rogerclarkmelbourne/Arduino_STM32

Tested with $2 STM32F103C8T6 "blue pill" board and $2 ST link V2
Also tested with GD32F103C8T6
