### PR TITLE
Update browse.path when include library

### DIFF
--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -229,6 +229,20 @@ export class ArduinoApp {
             configSection.includePath.push(childLibPath);
         });
 
+        libPaths.forEach((childLibPath) => {
+            childLibPath = path.resolve(path.normalize(childLibPath));
+            if (configSection.browse.path && configSection.browse.path.length) {
+                for (const existingPath of configSection.browse.path) {
+                    if (childLibPath === path.resolve(path.normalize(existingPath))) {
+                        return;
+                    }
+                }
+            } else {
+                configSection.browse.path = [];
+            }
+            configSection.browse.path.push(childLibPath);
+        });
+
         fs.writeFileSync(configFilePath, JSON.stringify(deviceContext, null, 4));
     }
 


### PR DESCRIPTION
According to https://github.com/Microsoft/vscode-cpptools/blob/master/Documentation/LanguageServer/FAQ.md#what-is-the-difference-between-includepath-and-browsepath-in-c_cpp_propertiesjson

> it is still important to ensure that the browse.path setting is properly set.

So browse.path is needed to be updated when including library, too.