### PR TITLE
New setting - commandPath - custom arduino launch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,14 @@ The following Visual Studio Code settings are available for the Arduino extensio
 ```json
 {
     "arduino.path": "C:/Program Files (x86)/Arduino",
+    "arduino.commandPath": "run-arduino.bat",
     "arduino.additionalUrls": "",
-    "arduino.logLevel": "info", 
+    "arduino.logLevel": "info",
     "arduino.enableUSBDetection": true
 }
 ```
 - `arduino.path` - Path to Arduino, you can use a custom version of Arduino by modifying this setting to include the full path. Example: `C:\\Program Files\\Arduino` for Windows, `/Applications` for Mac, `/home/$user/Downloads/arduino-1.8.1` for Linux. (Requires a restart after change). The default value is automatically detected from your Arduino IDE installation path.
+- `arduino.commandPath` - Path to an executable (or script) relative to `arduino.path`. You can use a custom launch script to run Arduino by modifying this setting. (Requires a restart after change) Example: `run-arduino.bat` for Windows, `Contents/MacOS/run-arduino.sh` for Mac, `bin/run-arduino.sh` for Linux."
 - `arduino.additionalUrls` - Additional URLs for 3rd party packages. You can have multiple URLs in one string with comma(,) as separator, or have a string array. The default value is empty.
 - `arduino.logLevel` - CLI output log level. Could be info or verbose. The default value is `"info"`.
 - `arduino.enableUSBDetection` - Enable/disable USB detection from the VSCode Arduino extension. The default value is `true`.

--- a/package.json
+++ b/package.json
@@ -413,6 +413,11 @@
           "default": "",
           "description": "Path to Arduino, you can use a custom version of Arduino by modifying this setting to include the full path. Example: 'C:\\Program Files\\Arduino' for Windows, '/Applications' for Mac, '/home/$user/Downloads/arduino-1.8.1' for Linux. (Requires a restart after change)"
         },
+        "arduino.commandPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to executable within 'arduino.path', you can use a custom script to run Arduino by modifying this setting to include the relative path. Example: 'run-arduino.bat' for Windows, 'Contents/MacOS/run-arduino.sh' for Mac, 'bin/run-arduino.sh' for Linux. (Requires a restart after change)"
+        },
         "arduino.additionalUrls": {
           "type": [
             "string",

--- a/package.json
+++ b/package.json
@@ -416,7 +416,7 @@
         "arduino.commandPath": {
           "type": "string",
           "default": "",
-          "description": "Path to executable within 'arduino.path', you can use a custom script to run Arduino by modifying this setting to include the relative path. Example: 'run-arduino.bat' for Windows, 'Contents/MacOS/run-arduino.sh' for Mac, 'bin/run-arduino.sh' for Linux. (Requires a restart after change)"
+          "description": "Path to a script relative to 'arduino.path', you can use a custom launch script to run Arduino by modifying this setting. Example: 'run-arduino.bat' for Windows, 'Contents/MacOS/run-arduino.sh' for Mac, 'bin/run-arduino.sh' for Linux. (Requires a restart after change)"
         },
         "arduino.additionalUrls": {
           "type": [

--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -27,6 +27,8 @@ export interface IArduinoSettings {
 export class ArduinoSettings implements IArduinoSettings {
     private _arduinoPath: string;
 
+    private _commandPath: string;
+
     private _packagePath: string;
 
     private _sketchbookPath: string;
@@ -38,15 +40,25 @@ export class ArduinoSettings implements IArduinoSettings {
 
     public async initialize() {
         const platform = os.platform();
+        this._commandPath = VscodeSettings.getInstance().commandPath;
         await this.tryResolveArduinoPath();
         if (platform === "win32") {
             await this.updateWindowsPath();
+            if (this._commandPath === "") {
+                this._commandPath = "arduino_debug.exe";
+            }
         } else if (platform === "linux") {
             this._packagePath = path.join(process.env.HOME, ".arduino15");
             this._sketchbookPath = this.preferences.get("sketchbook.path") || path.join(process.env.HOME, "Arduino");
+            if (this._commandPath === "") {
+                this._commandPath = "arduino";
+            }
         } else if (platform === "darwin") {
             this._packagePath = path.join(process.env.HOME, "Library/Arduino15");
             this._sketchbookPath = this.preferences.get("sketchbook.path") || path.join(process.env.HOME, "Documents/Arduino");
+            if (this._commandPath === "") {
+                this._commandPath = "/Contents/MacOS/Arduino";
+            }
         }
     }
 
@@ -85,11 +97,9 @@ export class ArduinoSettings implements IArduinoSettings {
     public get commandPath(): string {
         const platform = os.platform();
         if (platform === "darwin") {
-            return path.join(util.resolveMacArduinoAppPath(this._arduinoPath), path.normalize("/Contents/MacOS/Arduino"));
-        } else if (platform === "linux") {
-            return path.join(this._arduinoPath, "arduino");
-        } else if (platform === "win32") {
-            return path.join(this._arduinoPath, "arduino_debug.exe");
+            return path.join(util.resolveMacArduinoAppPath(this._arduinoPath), path.normalize(this._commandPath));
+        } else {
+            return path.join(this._arduinoPath, path.normalize(this._commandPath));
         }
     }
 

--- a/src/arduino/vscodeSettings.ts
+++ b/src/arduino/vscodeSettings.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 
 const configKeys = {
     ARDUINO_PATH: "arduino.path",
+    ARDUINO_COMMAND_PATH: "arduino.commandPath",
     ADDITIONAL_URLS: "arduino.additionalUrls",
     LOG_LEVEL: "arduino.logLevel",
     AUTO_UPDATE_INDEX_FILES: "arduino.autoUpdateIndexFiles",
@@ -13,6 +14,7 @@ const configKeys = {
 
 export interface IVscodeSettings {
     arduinoPath: string;
+    commandPath: string;
     additionalUrls: string | string[];
     logLevel: string;
     enableUSBDetection: boolean;
@@ -33,6 +35,10 @@ export class VscodeSettings implements IVscodeSettings {
 
     public get arduinoPath(): string {
         return this.getConfigValue<string>(configKeys.ARDUINO_PATH);
+    }
+
+    public get commandPath(): string {
+        return this.getConfigValue<string>(configKeys.ARDUINO_COMMAND_PATH);
     }
 
     public get additionalUrls(): string | string[] {


### PR DESCRIPTION
This change introduces a new workspace setting called `commandPath`.
Through this setting a user can specify a custom Arduino launch wrapper or script.

This is useful for example on macOS, to remove the default behaviour of showing the Arduino splash screen during sketch builds. To achieve this, one would create a launch script as described here: https://github.com/arduino/Arduino/issues/1970#issuecomment-321975809
Using the new `commandPath` setting, the user would instruct the vscode Arduino extension to invoke Arduino via this script, rather then the default binary.

When this setting is not configured or is an empty string value, the default Arduino binary is used as previously.

Default behavior is not changed. 

@andxu @testforstephen @akaroml