### PR TITLE
lazy check for serial port opening

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -25,7 +25,7 @@ export const messages = {
     INVALID_ARDUINO_PATH: "Cannot find the Arduino installation path. You can specify the path in the user settings.",
     FAILED_SEND_SERIALPORT: "Failed to send message to serial port.",
     SERIAL_PORT_NOT_STARTED: "Serial Monitor has not been started.",
-    SEND_BEFORE_OPEN_SERIALPORT: "Please open a serial port first.",
+    SEND_BEFORE_OPEN_SERIALPORT: "Please open Serial Monitor first.",
 };
 
 export const statusBarPriority = {


### PR DESCRIPTION
Related issue: https://github.com/Microsoft/vscode-arduino/issues/530 TestingOpen output on the serial monitor

This is a workaround for serial port opening test. To avoid disturbing user, I remove auto sending TestingOpen after serial port opened.

**This fix may cause a small issue:**

When we get serial port open event, we print a message says `Opened the serial port`. However, we cannot verify if the serial port open successfully until the user send some text by using `sendMessage` (related issue logged here: https://github.com/EmergingTechnologyAdvisors/node-serialport/issues/795). 

Thus, the user may see two contradictory messages after send some text in a chance, one says serial port opened, one says open serial port opened failed.