### PR TITLE
First try to fix intelliSense issue

### DIFF
--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -240,7 +240,7 @@ export class ArduinoApp {
             } else {
                 configSection.includePath = [];
             }
-            configSection.includePath.push(childLibPath);
+            configSection.includePath.unshift(childLibPath);
         });
 
         libPaths.forEach((childLibPath) => {
@@ -254,7 +254,7 @@ export class ArduinoApp {
             } else {
                 configSection.browse.path = [];
             }
-            configSection.browse.path.push(childLibPath);
+            configSection.browse.path.unshift(childLibPath);
         });
 
         fs.writeFileSync(configFilePath, JSON.stringify(deviceContext, null, 4));
@@ -437,14 +437,33 @@ export class ArduinoApp {
 
                 // Generate cpptools intellisense config
                 const cppConfigFilePath = path.join(destExample, constants.CPP_CONFIG_FILE);
+
+                // Current workspace
+                const includePath = ["${workspaceRoot}"];
+                // Defaut package for this board
+                includePath.concat(this.getDefaultPackageLibPaths());
+                // Arduino built-in package tools
+                includePath.push(path.join(this._settings.arduinoPath, "hardware", "tools"));
+                // Arduino built-in libraries
+                includePath.push(path.join(this._settings.arduinoPath, "libraries"));
+                // Arduino custom package tools
+                includePath.push(path.join(os.homedir(), "Documents", "Arduino", "hardware", "tools"));
+                // Arduino custom libraries
+                includePath.push(path.join(os.homedir(), "Documents", "Arduino", "libraries"));
+
                 const cppConfig = {
                     configurations: [{
                         name: util.getCppConfigPlatform(),
-                        includePath: this.getDefaultPackageLibPaths(),
+                        includePath,
                         browse: {
+                            path: includePath,
                             limitSymbolsToIncludedHeaders: false,
                         },
+                        intelliSenseMode: "clang-x64",
+                        cStandard: "c11",
+                        cppStandard: "c++17",
                     }],
+                    version: 3,
                 };
                 util.mkdirRecursivelySync(path.dirname(cppConfigFilePath));
                 fs.writeFileSync(cppConfigFilePath, JSON.stringify(cppConfig, null, 4));


### PR DESCRIPTION
Related issue: https://github.com/Microsoft/vscode-arduino/issues/438

This is not the final solution.

We still have some work to do...

intelliSense works in the most time with this fix, however, I have to include Arduino.h in the built in example, or built in functions are marked as undefined:

![1](https://user-images.githubusercontent.com/1621293/39349922-3e19219c-4a2f-11e8-9bae-2c9fe2c1bb89.png)

Then I include Arduino.h manually, intelliSense works:

![2](https://user-images.githubusercontent.com/1621293/39349972-5cc8cee4-4a2f-11e8-9182-5e0bc6e56c1d.png)

BUT, as you can see, there is still a warning message in include section - some header file required by Arduino.h is not found in include path of c_cpp_properties.json.

Include path is not recursive currently. And it is also not possible to add all header files into c_cpp_properties.json. So what we can do on fixing this error is very limited.

intelliSense should just work now, except for include part...

![](https://puxccbo05z-flywheel.netdna-ssl.com/wp-content/uploads/2015/02/ratel-2-340x200.jpg)