### PR TITLE
Adds way to skip header file provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ The following Visual Studio Code settings are available for the Arduino extensio
     "arduino.additionalUrls": "",
     "arduino.logLevel": "info",
     "arduino.enableUSBDetection": true,
-    "arduino.disableTestingOpen": false
+    "arduino.disableTestingOpen": false,
+    "arduino.skipHeaderProvider": false,
 }
 ```
 - `arduino.path` - Path to Arduino, you can use a custom version of Arduino by modifying this setting to include the full path. Example: `C:\\Program Files\\Arduino` for Windows, `/Applications` for Mac, `/home/$user/Downloads/arduino-1.8.1` for Linux. (Requires a restart after change). The default value is automatically detected from your Arduino IDE installation path.
@@ -69,6 +70,7 @@ The following Visual Studio Code settings are available for the Arduino extensio
 - `arduino.logLevel` - CLI output log level. Could be info or verbose. The default value is `"info"`.
 - `arduino.enableUSBDetection` - Enable/disable USB detection from the VSCode Arduino extension. The default value is `true`.
 - `arduino.disableTestingOpen` - Disable/enable auto sending a test message to serial port for checking open status. The default value is `false` (a test message will be sent).
+- `arduino.skipHeaderProvider` - Enable/disable the extension providing completion items for headers. The functionality is included in newer versions of the C++ extension. The default value is `false`.
 
 The following settings are per sketch settings of the Arduino extension. You can find them in
 `.vscode/arduino.json` under the workspace.

--- a/package.json
+++ b/package.json
@@ -454,6 +454,10 @@
         "arduino.ignoreBoards": {
           "type": "array",
           "default": []
+        },
+        "arduino.skipHeaderProvider": {
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/src/arduino/vscodeSettings.ts
+++ b/src/arduino/vscodeSettings.ts
@@ -12,6 +12,7 @@ const configKeys = {
     ENABLE_USB_DETECTOIN: "arduino.enableUSBDetection",
     DISABLE_TESTING_OPEN: "arduino.disableTestingOpen",
     IGNORE_BOARDS: "arduino.ignoreBoards",
+    SKIP_HEADER_PROVIDER: "arduino.skipHeaderProvider",
 };
 
 export interface IVscodeSettings {
@@ -22,6 +23,7 @@ export interface IVscodeSettings {
     enableUSBDetection: boolean;
     disableTestingOpen: boolean;
     ignoreBoards: string[];
+    skipHeaderProvider: boolean;
     updateAdditionalUrls(urls: string | string[]): void;
 }
 
@@ -67,6 +69,10 @@ export class VscodeSettings implements IVscodeSettings {
 
     public set ignoreBoards(value: string[]) {
         this.setConfigValue(configKeys.IGNORE_BOARDS, value, true);
+    }
+
+    public get skipHeaderProvider(): boolean {
+        return this.getConfigValue<boolean>(configKeys.SKIP_HEADER_PROVIDER);
     }
 
     public async updateAdditionalUrls(value) {

--- a/src/langService/completionProvider.ts
+++ b/src/langService/completionProvider.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 import * as constants from "../common/constants";
 import * as util from "../common/util";
 
+import { VscodeSettings } from "../arduino/vscodeSettings";
 import ArduinoActivator from "../arduinoActivator";
 import ArduinoContext from "../arduinoContext";
 import { ArduinoWorkspace } from "../common/workspace";
@@ -35,6 +36,9 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
 
     public async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position):
          Promise<vscode.CompletionItem[]> {
+        if (VscodeSettings.getInstance().skipHeaderProvider) {
+            return [];
+        }
         if (!ArduinoContext.initialized) {
             await ArduinoActivator.activate();
         }


### PR DESCRIPTION
With the VsCode C++ extension 0.17, it now automatically handles #include providers when properly set up.

This shouldn't be completely removed from this extension as there are still some use cases, but this adds a way to disable the arduino extensions provider if the user wants to.