### PR TITLE
Fixed typo for "verifying" in status bar

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -150,7 +150,7 @@ export async function activate(context: vscode.ExtensionContext) {
             try {
                 await vscode.window.withProgress({
                     location: vscode.ProgressLocation.Window,
-                    title: "Arduino: Verifing...",
+                    title: "Arduino: Verifying...",
                 }, async () => {
                     await ArduinoContext.arduinoApp.verify();
                 });


### PR DESCRIPTION
Was originally "verifing": 
![2018-06-18 1](https://user-images.githubusercontent.com/18105223/41546195-05b2708a-72eb-11e8-859c-054d8be16e25.png)
