### PR TITLE
Add support for cmsis-dap with Keil Software vid

### DIFF
--- a/misc/debuggerUsbMapping.json
+++ b/misc/debuggerUsbMapping.json
@@ -69,5 +69,16 @@
         "name": "CMSIS-DAP",
         "short_name": "cmsis-dap",
         "config_file": "cmsis-dap.cfg"
+    },
+    {
+        "vid": "c251",
+        "pid": [
+            "f001",
+            "f002",
+            "2722"
+        ],
+        "name": "CMSIS-DAP",
+        "short_name": "cmsis-dap",
+        "config_file": "cmsis-dap.cfg"
     }
 ]


### PR DESCRIPTION
Referring to
https://github.com/01org/OpenOCD/blob/master/src/jtag/drivers/cmsis_dap_usb.c
Line 49
/* Known vid/pid pairs:
 * VID 0xc251: Keil Software
 * PID 0xf001: LPC-Link-II CMSIS_DAP
 * PID 0xf002: OPEN-SDA CMSIS_DAP (Freedom Board)
 * PID 0x2722: Keil ULINK2 CMSIS-DAP
 *
 * VID 0x0d28: mbed Software
 * PID 0x0204: MBED CMSIS-DAP
 */