### PR TITLE
apply commit #653 also to upload using programmer

### DIFF
--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -206,7 +206,14 @@ export class ArduinoApp {
         }
         if (dc.output) {
             const outputPath = path.resolve(ArduinoWorkspace.rootPath, dc.output);
+            const dirPath = path.dirname(outputPath);
+            if (!util.directoryExistsSync(dirPath)) {
+                Logger.notifyUserError("InvalidOutPutPath", new Error(constants.messages.INVALID_OUTPUT_PATH + outputPath));
+                return;
+            }
+
             args.push("--pref", `build.path=${outputPath}`);
+            arduinoChannel.info(`Please see the build logs in Output path: ${outputPath}`);
         } else {
             const msg = "Output path is not specified. Unable to reuse previously compiled files. Upload could be slow. See README.";
             arduinoChannel.warning(msg);


### PR DESCRIPTION
hello, with commit #653 the output path not existing issue was fixed by @czgtest 
he did it for upload and verify but the arduino IDE so vscode have also another method of upload "upload with programmer" 
in this pull request i didn't did nothing special, i just copy-paste the good fix of czgtest to the other upload method