### PR TITLE
add debugging support for uno

### DIFF
--- a/misc/debuggerUsbMapping.json
+++ b/misc/debuggerUsbMapping.json
@@ -69,5 +69,12 @@
         "name": "CMSIS-DAP",
         "short_name": "cmsis-dap",
         "config_file": "cmsis-dap.cfg"
+    },
+    {
+        "vid": "1781",
+        "pid": "0c9f",
+        "name": "USBtinySPI",
+        "short_name": "debugWIRE",
+        "config_file": ""
     }
 ]

--- a/misc/usbmapping.json
+++ b/misc/usbmapping.json
@@ -3,6 +3,13 @@
     "index_file": "package_index.json",
     "boards": [
       {
+        "name": "Arduino/Genuino Uno",
+        "package": "arduino",
+        "architecture": "avr",
+        "id": "uno",
+        "interface": "debugWIRE"          
+      },            
+      {
         "vid": "2341",
         "pid": "804e",
         "name": "Arduino/Genuino MKR1000",


### PR DESCRIPTION
There is an opensource [debugWIRE implementation](https://github.com/dcwbrown/dwire-debug) that can debug Arduino Uno.

By adding config into the 2 json files, VScode will be capable to debug Arduino Uno. 

Here is an instruction https://github.com/DeqingSun/Debugging-Arduino-Uno