### PR TITLE
Add Wio LTE M1/NB1(BG96) board

### DIFF
--- a/misc/usbmapping.json
+++ b/misc/usbmapping.json
@@ -213,6 +213,14 @@
         "id": "Wio3G",
         "interface": "cmsis-dap.cfg",
         "target": "stm32f4x.cfg"
+      },
+      {
+        "name": "Seeed Wio LTE M1/NB1(BG96)",
+        "package": "SeeedJP",
+        "architecture": "SeeedJP_STM32F4",
+        "id": "WioLTEM1BG96",
+        "interface": "cmsis-dap.cfg",
+        "target": "stm32f4x.cfg"
       }
     ]
   }


### PR DESCRIPTION
The board is distributed by SORACOM only.
https://soracom.jp/products/module/wio_lte_m1_nb1/

Verify result:
![image](https://user-images.githubusercontent.com/8079404/48244601-edd8ca80-e429-11e8-855d-3aba57f3348c.png)
![image](https://user-images.githubusercontent.com/8079404/48244610-f8935f80-e429-11e8-8a40-2d166f014f03.png)
