### PR TITLE
Fix incorrect regular expression.

### DIFF
--- a/src/arduino/board.ts
+++ b/src/arduino/board.ts
@@ -8,7 +8,7 @@ export function parseBoardDescriptor(boardDescriptor: string, plat: IPlatform): 
     const boardLineRegex = /([^\.]+)\.(\S+)=(.+)/;
 
     const result = new Map<string, IBoard>();
-    const lines = boardDescriptor.split(/[\r|\r\n|\n]/);
+    const lines = boardDescriptor.split(/\r?\n/);
     const menuMap = new Map<string, string>();
 
     lines.forEach((line) => {


### PR DESCRIPTION
The regular expression includes pipes in the alternation, which means it matches literal pipes. It also doesn't correctly split by \r\n (splitting out an extra empty string). Test cases at https://repl.it/repls/KeyEqualUtility.

I have not tested this within the context of the application.