### PR TITLE
Export compiled binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-arduino",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -40,6 +40,15 @@
       "resolved": "https://registry.npmjs.org/@types/compare-versions/-/compare-versions-3.0.0.tgz",
       "integrity": "sha512-HNXtUQQuW3ThO9DVfTNbdvClVr+8AZlNNa2pxk5qtEvObnT27qh0DdQXTN4h5PuTTGinxwXkRKXsllJxuAzGPw==",
       "dev": true
+    },
+    "@types/fs-extra": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
+      "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/mocha": {
       "version": "2.2.48",
@@ -2630,6 +2639,16 @@
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
@@ -3550,8 +3569,7 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "growl": {
       "version": "1.10.3",
@@ -4959,6 +4977,14 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -7891,6 +7917,11 @@
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "activationEvents": [
     "*",
     "onCommand:arduino.verify",
+    "onCommand:arduino.exportCompiledBinary",
     "onCommand:arduino.upload",
     "onCommand:arduino.uploadUsingProgrammer",
     "onCommand:arduino.selectProgrammer",
@@ -76,6 +77,10 @@
           "dark": "images/ArduinoVerify_inverse_16.svg",
           "light": "images/ArduinoVerify_16.svg"
         }
+      },
+      {
+        "command": "arduino.exportCompiledBinary",
+        "title": "Arduino: Export Compiled Binary"
       },
       {
         "command": "arduino.upload",
@@ -538,6 +543,7 @@
   ],
   "devDependencies": {
     "@types/compare-versions": "^3.0.0",
+    "@types/fs-extra": "^5.0.4",
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.40",
     "@types/winreg": "^1.2.30",
@@ -568,6 +574,7 @@
     "compare-versions": "^3.4.0",
     "eventemitter2": "^4.1.0",
     "express": "^4.14.1",
+    "fs-extra": "^7.0.1",
     "glob": "^7.1.1",
     "iconv-lite": "^0.4.18",
     "properties": "^1.2.1",

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -2,10 +2,12 @@
 // Licensed under the MIT license.
 
 import * as fs from "fs";
+import * as fs_extra from "fs-extra"; // TODO: Remove to keep only standard fs when upgrading to Node 8+
 import * as glob from "glob";
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
+import * as uuidv4 from "uuid/v4";
 
 import * as constants from "../common/constants";
 import * as util from "../common/util";
@@ -239,7 +241,7 @@ export class ArduinoApp {
         });
     }
 
-    public async verify(output: string = "") {
+    public async verify(output: string = "", export_binary: boolean = false) {
         const dc = DeviceContext.getInstance();
         const boardDescriptor = this.getBoardBuildString();
         if (!boardDescriptor) {
@@ -276,8 +278,10 @@ export class ArduinoApp {
         if (VscodeSettings.getInstance().logLevel === "verbose") {
             args.push("--verbose");
         }
+        var outputPath;
+        var isTmp = false;
         if (output || dc.output) {
-            const outputPath = path.resolve(ArduinoWorkspace.rootPath, output || dc.output);
+            outputPath = path.resolve(ArduinoWorkspace.rootPath, output || dc.output);
             const dirPath = path.dirname(outputPath);
             if (!util.directoryExistsSync(dirPath)) {
                 Logger.notifyUserError("InvalidOutPutPath", new Error(constants.messages.INVALID_OUTPUT_PATH + outputPath));
@@ -289,6 +293,12 @@ export class ArduinoApp {
         } else {
             const msg = "Output path is not specified. Unable to reuse previously compiled files. Verify could be slow. See README.";
             arduinoChannel.warning(msg);
+            if (export_binary) {
+                const uuid = uuidv4();
+                outputPath = path.join(os.tmpdir(), uuid);
+                args.push("--pref", `build.path=${outputPath}`);
+                isTmp = true;
+            }
         }
 
         arduinoChannel.show();
@@ -296,12 +306,44 @@ export class ArduinoApp {
         try {
             await util.spawn(this._settings.commandPath, arduinoChannel.channel, args);
             arduinoChannel.end(`Finished verify sketch - ${dc.sketch}${os.EOL}`);
+            if (export_binary) {
+                const options = {
+                    nodir: true,
+                    realpath: true,
+                    absolute: true
+                };
+                glob(path.join(outputPath, "/*.{hex,bin,elf}"), options, (err, files: string[]) => {
+                    if (err) {
+                        arduinoChannel.warning(`Couldn't find binary files, glob returned ${err}`);
+                    } else {
+                        files.forEach(async (bin) => {
+                            // TODO: Replace fs_extra.copy by fs.copyFile when upgrading to Node 8+
+                            await fs_extra.copy(bin, path.join(ArduinoWorkspace.rootPath, path.basename(bin)), (err: Error) => {
+                                if (err) {
+                                    arduinoChannel.warning(`Couldn't copy binary file ${bin}, copy returned ${err}`);
+                                }
+                            });
+                        });
+                        if (isTmp) {
+                            fs_extra.remove(outputPath, (err: Error) => {
+                                if (err) {
+                                    arduinoChannel.warning(`Couldn't remove temporary build directory ${outputPath}, rm returned ${err}`);
+                                }
+                            });
+                        }
+                    }
+                });
+            }
             return true;
         } catch (reason) {
             arduinoChannel.error(`Exit with code=${reason.code}${os.EOL}`);
             return false;
         }
 
+    }
+
+    public async exportCompiledBinary(output: string = "") {
+        return this.verify(output, true);
     }
 
     // Add selected library path to the intellisense search path.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,6 +185,24 @@ export async function activate(context: vscode.ExtensionContext) {
         return { board: (ArduinoContext.boardManager.currentBoard === null) ? null : ArduinoContext.boardManager.currentBoard.name };
     });
 
+    registerArduinoCommand("arduino.exportCompiledBinary", async () => {
+        if (!status.compile) {
+            status.compile = "verify";
+            try {
+                await vscode.window.withProgress({
+                    location: vscode.ProgressLocation.Window,
+                    title: "Arduino: Exporting Compiled Binary...",
+                }, async () => {
+                    await ArduinoContext.arduinoApp.exportCompiledBinary();
+                });
+            } catch (ex) {
+            }
+            delete status.compile;
+        }
+    }, () => {
+        return { board: (ArduinoContext.boardManager.currentBoard === null) ? null : ArduinoContext.boardManager.currentBoard.name };
+    });
+
     registerArduinoCommand("arduino.upload", async () => {
         if (!status.compile) {
             status.compile = "upload";

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -113,4 +113,18 @@ suite("Arduino: Commands Tests", () => {
         }
     });
 
+    test("should be able to run command: arduino exportCompiledBinary", function(done) {
+        // Same timeout as verify, being the longest part of the command
+        this.timeout(3 * 60 * 1000);
+        try {
+            // run "Arduino: Export Compiled Binary" command.
+            vscode.commands.executeCommand("arduino.exportCompiledBinary").then((result)  => {
+                done();
+            });
+
+        } catch (error) {
+            done(new Error(error));
+        }
+    });
+
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -33,6 +33,7 @@ suite("Arduino: Extension Tests", () => {
             return vscode.commands.getCommands(true).then((commands) => {
                 const ARDUINO_COMMANDS = [
                     "arduino.verify",
+                    "arduino.exportCompiledBinary",
                     "arduino.upload",
                     "arduino.uploadUsingProgrammer",
                     "arduino.selectProgrammer",


### PR DESCRIPTION
Hi! I added an "Export Compiled Binary" command such as the one in the Arduino IDE (but currently not in the Arduino CLI) which copies the compiled binaries of a sketch in the sketch folder.

I know it's possible to get them by setting the `output` parameter in `arduino.json` but at least it adds an alternate option invokable directly by its command and not requiring to keep the full build directory if we just want to keep the binaries.

Thanks for your reviews and comments