### PR TITLE
Workaround for multiple projects in same workspace

### DIFF
--- a/src/deviceContext.ts
+++ b/src/deviceContext.ts
@@ -191,16 +191,15 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
     }
 
     public showStatusBar() {
-        if (this._sketch == null) {
+        if (this._sketch === null) {
             this._sketchStatusBar.text = "<Set Sketch>";
-        }
-        else{
+        }else {
             this._sketchStatusBar.text = this._sketch;
         }
         this._sketchStatusBar.show();
     }
 
-    updateStatusBar(){
+    public updateStatusBar() {
         this._sketchStatusBar.text = this._sketch;
     }
 
@@ -353,7 +352,7 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
                     }
                 } else if (fileUris.length === 1) {
                     this.sketch = path.relative(ArduinoWorkspace.rootPath, fileUris[0].fsPath);
-                    this.updateStatusBar()
+                    this.updateStatusBar();
                 } else if (fileUris.length > 1) {
                     const chosen = await vscode.window.showQuickPick(<vscode.QuickPickItem[]>fileUris.map((fileUri): vscode.QuickPickItem => {
                         return <vscode.QuickPickItem>{
@@ -363,7 +362,7 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
                     }), { placeHolder: "Select the main sketch file" });
                     if (chosen && chosen.label) {
                         this.sketch = chosen.label;
-                        this.updateStatusBar()
+                        this.updateStatusBar();
                     }
                 }
             });

--- a/src/deviceContext.ts
+++ b/src/deviceContext.ts
@@ -191,9 +191,14 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
     }
 
     public showStatusBar() {
-        if (!this._sketch) {
-            return false;
+        if (this._sketch == null) {
+            this._sketchStatusBar.text = "<Set Sketch>";
         }
+        else{
+            this._sketchStatusBar.text = this._sketch;
+        }
+        this._sketchStatusBar.show();
+    }
 
         this._sketchStatusBar.text = this._sketch;
         this._sketchStatusBar.show();

--- a/src/deviceContext.ts
+++ b/src/deviceContext.ts
@@ -110,7 +110,7 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
             this._watcher.onDidDelete(() => this.loadContext());
             this._vscodeWatcher.onDidDelete(() => this.loadContext());
             this._sketchStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, constants.statusBarPriority.SKETCH);
-            this._sketchStatusBar.command = "arduino.setSketchFile";
+            this._sketchStatusBar.command = "arduino.resolveSketchFile";
             this._sketchStatusBar.tooltip = "Sketch File";
         }
     }

--- a/src/deviceContext.ts
+++ b/src/deviceContext.ts
@@ -200,8 +200,8 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
         this._sketchStatusBar.show();
     }
 
+    updateStatusBar(){
         this._sketchStatusBar.text = this._sketch;
-        this._sketchStatusBar.show();
     }
 
     public saveContext() {

--- a/src/deviceContext.ts
+++ b/src/deviceContext.ts
@@ -353,6 +353,7 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
                     }
                 } else if (fileUris.length === 1) {
                     this.sketch = path.relative(ArduinoWorkspace.rootPath, fileUris[0].fsPath);
+                    this.updateStatusBar()
                 } else if (fileUris.length > 1) {
                     const chosen = await vscode.window.showQuickPick(<vscode.QuickPickItem[]>fileUris.map((fileUri): vscode.QuickPickItem => {
                         return <vscode.QuickPickItem>{
@@ -362,6 +363,7 @@ export class DeviceContext implements IDeviceContext, vscode.Disposable {
                     }), { placeHolder: "Select the main sketch file" });
                     if (chosen && chosen.label) {
                         this.sketch = chosen.label;
+                        this.updateStatusBar()
                     }
                 }
             });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,6 +225,10 @@ export async function activate(context: vscode.ExtensionContext) {
         deviceContext.showStatusBar();
     });
 
+    registerArduinoCommand("arduino.resolveSketchFile", async () => {
+        deviceContext.resolveMainSketch();
+    });
+
     registerArduinoCommand("arduino.uploadUsingProgrammer", async () => {
         if (!status.compile) {
             status.compile = "upload";

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -54,6 +54,7 @@ suite("Arduino: Extension Tests", () => {
                     "arduino.loadPackages",
                     "arduino.installBoard",
                     "arduino.setSketchFile",
+                    "arduino.resolveSketchFile",
                 ];
 
                 const foundArduinoCommands = commands.filter((value) => {


### PR DESCRIPTION
I wanted to solve multiple ino files in same workspace , and wanted to resolve #839 could be assumed as workaround for #476 aswell.

* If workspace does not have sketch file defined <Set Sketch>
* In order to change current sketch clicking to status bar is enough which lists all posible sketches in workspace

it seemed easier to click a select a sketch rather than writing full path name.
