### PR TITLE
Remove Processing Filetype (.PDE extension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This extension provides several commands in the Command Palette (<kbd>F1</kbd> o
 | `arduino.commandPath` | Path to an executable (or script) relative to `arduino.path`. The default value is `arduino_debug.exe` for windows,`Contents/MacOS/Arduino` for Mac and `arduino` for Linux, You also can use a custom launch script to run Arduino by modifying this setting. (Requires a restart after change) Example: `run-arduino.bat` for Windows, `Contents/MacOS/run-arduino.sh` for Mac and `bin/run-arduino.sh` for Linux. |
 | `arduino.additionalUrls` | Additional Boards Manager URLs for 3rd party packages. You can have multiple URLs in one string with a comma(`,`) as separator, or have a string array. The default value is empty. |
 | `arduino.logLevel` | CLI output log level. Could be info or verbose. The default value is `"info"`. |
+| `arduino.allowPDEFiletype` | Allow the VSCode Arduino extension to open .pde files from pre-1.0.0 versions of Ardiuno. Note that this will break Processing code. Default value is `false`. | 
 | `arduino.enableUSBDetection` | Enable/disable USB detection from the VSCode Arduino extension. The default value is `true`. When your device is plugged in to your computer, it will pop up a message "`Detected board ****, Would you like to switch to this board type`". After clicking the `Yes` button, it will automatically detect which serial port (COM) is connected a USB device. If your device does not support this feature, please provide us with the PID/VID of your device; the code format is defined in `misc/usbmapping.json`.To learn more about how to list the vid/pid, use the following tools: https://github.com/EmergingTechnologyAdvisors/node-serialport `npm install -g serialport` `serialport-list -f jsonline`|
 | `arduino.disableTestingOpen` | Enable/disable automatic sending of a test message to the serial port for checking the open status. The default value is `false` (a test message will be sent). |
 | `arduino.skipHeaderProvider` | Enable/disable the extension providing completion items for headers. This functionality is included in newer versions of the C++ extension. The default value is `false`.|
@@ -74,6 +75,7 @@ The following Visual Studio Code settings are available for the Arduino extensio
     "arduino.path": "C:/Program Files (x86)/Arduino",
     "arduino.commandPath": "arduino_debug.exe",
     "arduino.logLevel": "info",
+    "arduino.allowPDEFiletype": false, 
     "arduino.enableUSBDetection": true,
     "arduino.disableTestingOpen": false,
     "arduino.skipHeaderProvider": false,

--- a/package.json
+++ b/package.json
@@ -505,8 +505,7 @@
       {
         "id": "cpp",
         "extensions": [
-          ".ino",
-          ".pde"
+          ".ino"
         ]
       }
     ],

--- a/package.json
+++ b/package.json
@@ -465,6 +465,11 @@
             "verbose"
           ]
         },
+        "arduino.openPDEFiletype":{
+          "type":"boolean",
+          "default":false,
+          "description": "Allow VSCode Arduino to open PDE sketches, from pre-1.0.0 versions of Arduino"
+        },
         "arduino.enableUSBDetection": {
           "type": "boolean",
           "default": true

--- a/src/arduino/vscodeSettings.ts
+++ b/src/arduino/vscodeSettings.ts
@@ -9,7 +9,8 @@ const configKeys = {
     ADDITIONAL_URLS: "arduino.additionalUrls",
     LOG_LEVEL: "arduino.logLevel",
     AUTO_UPDATE_INDEX_FILES: "arduino.autoUpdateIndexFiles",
-    ENABLE_USB_DETECTOIN: "arduino.enableUSBDetection",
+    ALLOW_PDE_FILETYPE: "arduino.allowPDEFiletype",    
+    ENABLE_USB_DETECTION: "arduino.enableUSBDetection",
     DISABLE_TESTING_OPEN: "arduino.disableTestingOpen",
     IGNORE_BOARDS: "arduino.ignoreBoards",
     SKIP_HEADER_PROVIDER: "arduino.skipHeaderProvider",
@@ -21,6 +22,7 @@ export interface IVscodeSettings {
     commandPath: string;
     additionalUrls: string | string[];
     logLevel: string;
+    allowPDEFiletype: boolean;
     enableUSBDetection: boolean;
     disableTestingOpen: boolean;
     ignoreBoards: string[];
@@ -57,8 +59,12 @@ export class VscodeSettings implements IVscodeSettings {
         return this.getConfigValue<string>(configKeys.LOG_LEVEL) || "info";
     }
 
+    public get allowPDEFiletype(): boolean {
+        return this.getConfigValue<boolean>(configKeys.ALLOW_PDE_FILETYPE);
+    }
+
     public get enableUSBDetection(): boolean {
-        return this.getConfigValue<boolean>(configKeys.ENABLE_USB_DETECTOIN);
+        return this.getConfigValue<boolean>(configKeys.ENABLE_USB_DETECTION);
     }
 
     public get disableTestingOpen(): boolean {

--- a/src/arduino/vscodeSettings.ts
+++ b/src/arduino/vscodeSettings.ts
@@ -9,7 +9,7 @@ const configKeys = {
     ADDITIONAL_URLS: "arduino.additionalUrls",
     LOG_LEVEL: "arduino.logLevel",
     AUTO_UPDATE_INDEX_FILES: "arduino.autoUpdateIndexFiles",
-    ALLOW_PDE_FILETYPE: "arduino.allowPDEFiletype",    
+    ALLOW_PDE_FILETYPE: "arduino.allowPDEFiletype",
     ENABLE_USB_DETECTION: "arduino.enableUSBDetection",
     DISABLE_TESTING_OPEN: "arduino.disableTestingOpen",
     IGNORE_BOARDS: "arduino.ignoreBoards",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -332,7 +332,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const allowPDEFiletype = vscodeSettings.allowPDEFiletype;
 
-    if(allowPDEFiletype){
+    if(allowPDEFiletype) {
         vscode.workspace.onDidOpenTextDocument(async (document) => {
             if (/\.pde$/.test(document.uri.fsPath)) {
                 const newFsName = document.uri.fsPath.replace(/\.pde$/, ".ino");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -332,7 +332,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const allowPDEFiletype = vscodeSettings.allowPDEFiletype;
 
-    if(allowPDEFiletype) {
+    if (allowPDEFiletype) {
         vscode.workspace.onDidOpenTextDocument(async (document) => {
             if (/\.pde$/.test(document.uri.fsPath)) {
                 const newFsName = document.uri.fsPath.replace(/\.pde$/, ".ino");


### PR DESCRIPTION
referencing issue #838 

This is really an annoying issue with these asking FOR pde support:
#217 #752 #793 
but they are all individually wrong:
PDE is for processing, arduino uses INO. Arduino DID use pde _prior to the first release_ ( as it was a cut-copy of Processing ) but now PDE on arduino is considered "read only" - [read more here](https://www.arduino.cc/en/guide/environment)

Now with Ardiuno on 1.8.9 and Processing on 3.5.3; Both popular, both being used in their own way, allowing people to use pde files for arduino is sacrilegious to both camps.

In regards to other arduino-based examples and etc using PDE. (Looking at #752 specifically ) The correct place to submit an issue is on THAT codebase to rename .pde; not for tools like this one to support pde. 

It also makes life difficult for people who use both Arduino and Processing in their educational work, such as myself. Any work I do in the Processing language is renamed to the Arduino extension automatically, and it doesn't need to be, because PDE is not arduino; INO is. 

I hope this closes the issue enough to not bring this up again; It's like typesafety for files; you can't rename an short an int and call it a day because now code compiles.
