### PR TITLE
Windows codepage bugfix

### DIFF
--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -23,7 +23,6 @@ import { ArduinoWorkspace } from "../common/workspace";
 import { SerialMonitor } from "../serialmonitor/serialMonitor";
 import { UsbDetector } from "../serialmonitor/usbDetector";
 import { ProgrammerManager } from "./programmerManager";
-import { messages } from './../common/constants';
 
 /**
  * Represent an Arduino application based on the official Arduino IDE.

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -23,6 +23,7 @@ import { ArduinoWorkspace } from "../common/workspace";
 import { SerialMonitor } from "../serialmonitor/serialMonitor";
 import { UsbDetector } from "../serialmonitor/usbDetector";
 import { ProgrammerManager } from "./programmerManager";
+import { messages } from './../common/constants';
 
 /**
  * Represent an Arduino application based on the official Arduino IDE.
@@ -133,7 +134,7 @@ export class ArduinoApp {
             const prebuildargs = dc.prebuild.split(" ");
             const prebuildCommand = prebuildargs.shift();
             try {
-                await util.spawn(prebuildCommand, arduinoChannel.channel, prebuildargs, {shell: true, cwd: ArduinoWorkspace.rootPath});
+                await util.spawn(prebuildCommand, arduinoChannel.channel, prebuildargs, { shell: true, cwd: ArduinoWorkspace.rootPath });
             } catch (ex) {
                 arduinoChannel.error(`Run prebuild failed: \n${ex.error}`);
                 return;
@@ -215,7 +216,7 @@ export class ArduinoApp {
 
         const appPath = path.join(ArduinoWorkspace.rootPath, dc.sketch);
         const args = ["--upload", "--board", boardDescriptor, "--port", dc.port, "--useprogrammer",
-                "--pref", "programmer=" + selectProgrammer, appPath];
+            "--pref", "programmer=" + selectProgrammer, appPath];
         if (VscodeSettings.getInstance().logLevel === "verbose") {
             args.push("--verbose");
         }
@@ -269,7 +270,7 @@ export class ArduinoApp {
             const prebuildargs = dc.prebuild.split(" ");
             const prebuildCommand = prebuildargs.shift();
             try {
-                await util.spawn(prebuildCommand, arduinoChannel.channel, prebuildargs, {shell: true, cwd: ArduinoWorkspace.rootPath});
+                await util.spawn(prebuildCommand, arduinoChannel.channel, prebuildargs, { shell: true, cwd: ArduinoWorkspace.rootPath });
             } catch (ex) {
                 arduinoChannel.error(`Run prebuild failed: \n${ex.error}`);
                 return;
@@ -303,7 +304,12 @@ export class ArduinoApp {
             arduinoChannel.end(`Finished verify sketch - ${dc.sketch}${os.EOL}`);
             return true;
         } catch (reason) {
-            arduinoChannel.error(`Exit with code=${reason.code}${os.EOL}`);
+            const msg = reason.code ?
+                `Exit with code=${reason.code}${os.EOL}` :
+                reason.message ?
+                    reason.message :
+                    JSON.stringify(reason);
+            arduinoChannel.error(msg);
             return false;
         }
 
@@ -315,7 +321,7 @@ export class ArduinoApp {
             return;
         }
         const cppConfigFile = fs.readFileSync(configFilePath, "utf8");
-        const cppConfig = JSON.parse(cppConfigFile) as {configurations: Array<{includePath: string[], forcedInclude: string[]}>};
+        const cppConfig = JSON.parse(cppConfigFile) as { configurations: Array<{ includePath: string[], forcedInclude: string[] }> };
         const libPaths = this.getDefaultPackageLibPaths();
         const defaultForcedInclude = this.getDefaultForcedIncludeFiles();
         const configuration = cppConfig.configurations[0];

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -10,7 +10,6 @@ import * as properties from "properties";
 import * as vscode from "vscode";
 import * as WinReg from "winreg";
 import { arduinoChannel } from "./outputChannel";
-import { messages } from './constants';
 
 const encodingMapping: object = JSON.parse(fs.readFileSync(path.join(__dirname, "../../../misc", "codepageMapping.json"), "utf8"));
 
@@ -211,10 +210,11 @@ export function spawn(command: string, outputChannel: vscode.OutputChannel, args
         let codepage = "65001";
         if (os.platform() === "win32") {
             try {
-                let chcp = childProcess.execSync("chcp");
+                const chcp = childProcess.execSync("chcp");
                 codepage = chcp.toString().split(":").pop().trim();
             } catch (error) {
-                arduinoChannel.warning(`Defaulting to code page 850 because chcp failed.\rEnsure your path includes %SystemRoot%\\system32\r${error.message}`);
+                arduinoChannel.warning(`Defaulting to code page 850 because chcp failed.\
+                \rEnsure your path includes %SystemRoot%\\system32\r${error.message}`);
                 codepage = "850";
             }
         }

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -214,7 +214,7 @@ export function spawn(command: string, outputChannel: vscode.OutputChannel, args
                 let chcp = childProcess.execSync("chcp");
                 codepage = chcp.toString().split(":").pop().trim();
             } catch (error) {
-                arduinoChannel.warning(`Defaulting to code page 850 because chcp failed.\rEnsure your path includes %SystemRoot%\system32\r${error.message}`);
+                arduinoChannel.warning(`Defaulting to code page 850 because chcp failed.\rEnsure your path includes %SystemRoot%\\system32\r${error.message}`);
                 codepage = "850";
             }
         }

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -9,6 +9,8 @@ import * as path from "path";
 import * as properties from "properties";
 import * as vscode from "vscode";
 import * as WinReg from "winreg";
+import { arduinoChannel } from "./outputChannel";
+import { messages } from './constants';
 
 const encodingMapping: object = JSON.parse(fs.readFileSync(path.join(__dirname, "../../../misc", "codepageMapping.json"), "utf8"));
 
@@ -208,7 +210,13 @@ export function spawn(command: string, outputChannel: vscode.OutputChannel, args
 
         let codepage = "65001";
         if (os.platform() === "win32") {
-            codepage = childProcess.execSync("chcp").toString().split(":").pop().trim();
+            try {
+                let chcp = childProcess.execSync("chcp");
+                codepage = chcp.toString().split(":").pop().trim();
+            } catch (error) {
+                arduinoChannel.warning(`Defaulting to code page 850 because chcp failed.\rEnsure your path includes %SystemRoot%\system32\r${error.message}`);
+                codepage = "850";
+            }
         }
 
         if (outputChannel) {


### PR DESCRIPTION
See #869 

When the path on a Windows machine is broken in such a way that chcp cannot be successfully invoked, an error occurs and the returned reason object does not have a code property as expected by the error handler. This results in the unhelpful error message `code=undefined`

There are two problems here: 
* defective error handling
* weak handling of a scenario for which there is a reasonable default

# Improved error handling
The catch clause checks whether `code` or `message` properties are present and falls back to stringifying the whole object.

# Reasonable default
The code page is 850 for the English speaking world. When a value cannot be obtained and the default is used a warning is generated that includes the error message returned from the attempt to invoke chcp.