### PR TITLE
Support custom libraries with portable version of Arduino

### DIFF
--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -670,7 +670,7 @@ Please make sure the folder is not occupied by other procedures .`);
                 // Arduino custom package tools
                 includePath.push(path.join(os.homedir(), "Documents", "Arduino", "hardware", "tools", "**"));
                 // Arduino custom libraries
-                includePath.push(path.join(os.homedir(), "Documents", "Arduino", "libraries", "**"));
+                includePath.push(path.join(this._settings.sketchbookPath, "libraries", "**"));
 
                 const forcedInclude = this.getDefaultForcedIncludeFiles();
 

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -668,7 +668,7 @@ Please make sure the folder is not occupied by other procedures .`);
                 // Arduino built-in libraries
                 includePath.push(path.join(this._settings.arduinoPath, "libraries", "**"));
                 // Arduino custom package tools
-                includePath.push(path.join(os.homedir(), "Documents", "Arduino", "hardware", "tools", "**"));
+                includePath.push(path.join(this._settings.sketchbookPath, "hardware", "tools", "**"));
                 // Arduino custom libraries
                 includePath.push(path.join(this._settings.sketchbookPath, "libraries", "**"));
 


### PR DESCRIPTION
When running with a portable version of Adruino IDE, the custom libraries are put in: 
--> arduino-1.8.10\portable\sketchbook\libraries
(and not in Documents\Arduino\libraries).

This PR replaces the hard coded ref to Documents\Arduino\libraries with a ref to _settings.sketchbookPath that works with the portable version and the installed one.