### PR TITLE
Persistent baud and line endings and related fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This extension provides several commands in the Command Palette (<kbd>F1</kbd> o
 | `arduino.commandPath` | Path to an executable (or script) relative to `arduino.path`. The default value is `arduino_debug.exe` for windows,`Contents/MacOS/Arduino` for Mac and `arduino` for Linux, You also can use a custom launch script to run Arduino by modifying this setting. (Requires a restart after change) Example: `run-arduino.bat` for Windows, `Contents/MacOS/run-arduino.sh` for Mac and `bin/run-arduino.sh` for Linux. |
 | `arduino.additionalUrls` | Additional Boards Manager URLs for 3rd party packages. You can have multiple URLs in one string with a comma(`,`) as separator, or have a string array. The default value is empty. |
 | `arduino.logLevel` | CLI output log level. Could be info or verbose. The default value is `"info"`. |
-| `arduino.allowPDEFiletype` | Allow the VSCode Arduino extension to open .pde files from pre-1.0.0 versions of Ardiuno. Note that this will break Processing code. Default value is `false`. | 
+| `arduino.allowPDEFiletype` | Allow the VSCode Arduino extension to open .pde files from pre-1.0.0 versions of Ardiuno. Note that this will break Processing code. Default value is `false`. |
 | `arduino.enableUSBDetection` | Enable/disable USB detection from the VSCode Arduino extension. The default value is `true`. When your device is plugged in to your computer, it will pop up a message "`Detected board ****, Would you like to switch to this board type`". After clicking the `Yes` button, it will automatically detect which serial port (COM) is connected a USB device. If your device does not support this feature, please provide us with the PID/VID of your device; the code format is defined in `misc/usbmapping.json`.To learn more about how to list the vid/pid, use the following tools: https://github.com/EmergingTechnologyAdvisors/node-serialport `npm install -g serialport` `serialport-list -f jsonline`|
 | `arduino.disableTestingOpen` | Enable/disable automatic sending of a test message to the serial port for checking the open status. The default value is `false` (a test message will be sent). |
 | `arduino.skipHeaderProvider` | Enable/disable the extension providing completion items for headers. This functionality is included in newer versions of the C++ extension. The default value is `false`.|
@@ -75,7 +75,7 @@ The following Visual Studio Code settings are available for the Arduino extensio
     "arduino.path": "C:/Program Files (x86)/Arduino",
     "arduino.commandPath": "arduino_debug.exe",
     "arduino.logLevel": "info",
-    "arduino.allowPDEFiletype": false, 
+    "arduino.allowPDEFiletype": false,
     "arduino.enableUSBDetection": true,
     "arduino.disableTestingOpen": false,
     "arduino.skipHeaderProvider": false,
@@ -95,6 +95,8 @@ The following settings are as per sketch settings of the Arduino extension. You 
 {
     "sketch": "example.ino",
     "port": "COM5",
+    "baud": 115200,
+    "ending": "No line ending",
     "board": "adafruit:samd:adafruit_feather_m0",
     "output": "../build",
     "debugger": "jlink",
@@ -103,6 +105,8 @@ The following settings are as per sketch settings of the Arduino extension. You 
 ```
 - `sketch` - The main sketch file name of Arduino.
 - `port` - Name of the serial port connected to the device. Can be set by the `Arduino: Select Serial Port` command. For Mac users could be "/dev/cu.wchusbserial1420".
+- `baud` - Baud rate for the serial port connected to the device, defaults to 115200. Can be any of the supported rates:  300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 250000.
+- `ending` - Line ending used for the serial monitor.  Can be any of the following: "No line ending", "Newline", "Carriage return", "Both NL & CR"
 - `board` - Currently selected Arduino board alias. Can be set by the `Arduino: Change Board Type` command. Also, you can find the board list there.
 - `output` - Arduino build output path. If not set, Arduino will create a new temporary output folder each time, which means it cannot reuse the intermediate result of the previous build leading to long verify/upload time, so it is recommended to set the field. Arduino requires that the output path should not be the workspace itself or in a subfolder of the workspace, otherwise, it may not work correctly. By default, this option is not set. It's worth noting that the contents of this file could be deleted during the build process, so pick (or create) a directory that will not store files you want to keep.
 - `debugger` - The short name of the debugger that will be used when the board itself does not have a debugger and there is more than one debugger available. You can find the list of debuggers [here](https://github.com/Microsoft/vscode-arduino/blob/master/misc/debuggerUsbMapping.json). By default, this option is not set.
@@ -157,6 +161,11 @@ To *run and develop*, do the following:
 - Press <kbd>F5</kbd> to debug.
 
 To *test*, press <kbd>F5</kbd> in VS Code with the "Launch Tests" debug configuration.
+
+Debugging:
+
+- Logger outputs messages higher than info to the file `arduino.log` in the root of your git repository.
+- `console.log("message")` will output messages to the Debug Console of the initial Visual Studio Code instance.
 
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct). For more information please see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/#howadopt) or contact opencode@microsoft.com with any additional questions or comments.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "onCommand:arduino.selectProgrammer",
     "onCommand:arduino.selectSerialPort",
     "onCommand:arduino.changeBaudRate",
+    "onCommand:arduino.changeEnding",
     "onCommand:arduino.addLibPath",
     "onCommand:arduino.openSerialMonitor",
     "onCommand:arduino.sendMessageToSerialPort",
@@ -100,6 +101,10 @@
       {
         "command": "arduino.changeBaudRate",
         "title": "Arduino: Change Baud Rate"
+      },
+      {
+        "command": "arduino.changeEnding",
+        "title": "Arduino: Change Line Ending"
       },
       {
         "command": "arduino.openSerialMonitor",

--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import * as WinReg from "winreg";
 import * as util from "../common/util";
+import * as constants from "../common/constants";
 
 import { resolveArduinoPath, validateArduinoPath } from "../common/platform";
 
@@ -219,9 +220,8 @@ export class ArduinoSettings implements IArduinoSettings {
     }
 
     private async tryGetDefaultBaudRate(): Promise<void> {
-        const supportBaudRates = [300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 250000];
         const configValue = VscodeSettings.getInstance().defaultBaudRate;
-        if (!configValue || supportBaudRates.indexOf(configValue) === -1) {
+        if (!configValue || constants.SUPPORTED_BAUD_RATES.indexOf(configValue) === -1) {
             this._defaultBaudRate = 0;
         } else {
             this._defaultBaudRate = configValue;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -33,11 +33,15 @@ export const messages = {
 };
 
 export const statusBarPriority = {
-    PORT: 20,
-    OPEN_PORT: 30,
-    BAUD_RATE: 40,
-    BOARD: 60,
-    ENDING: 70,
+    ENDING: 20,
+    BAUD_RATE: 21,
+    PORT: 22,
+    OPEN_PORT: 23,
+    BOARD: 70,
     SKETCH: 80,
     PROGRAMMER: 90,
 };
+
+export const DEFAULT_BAUD_RATE: number = 115200;
+export const SUPPORTED_BAUD_RATES: number[] = [ 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 250000 ];
+export const DEFAULT_LINE_ENDING = "No line ending";

--- a/src/serialmonitor/serialportctrl.ts
+++ b/src/serialmonitor/serialportctrl.ts
@@ -50,6 +50,7 @@ export class SerialPortCtrl {
     this._currentBaudRate = baudRate;
     this._currentPort = port;
     this._ending = ending;
+
   }
 
   public get isActive(): boolean {
@@ -61,7 +62,8 @@ export class SerialPortCtrl {
   }
 
   public open(): Promise<any> {
-    this._outputChannel.appendLine(`[Starting] Opening the serial port - ${this._currentPort}`);
+    this._outputChannel.appendLine(`[Starting] Opening the serial port - ${this._currentPort} @ ${this._currentBaudRate} baud.`);
+    this._outputChannel.appendLine(`[Info] Line Ending is ${SerialPortEnding[this._ending]}`);
     return new Promise((resolve, reject) => {
       if (this._currentSerialPort && this._currentSerialPort.isOpen()) {
         this._currentSerialPort.close((err) => {
@@ -101,7 +103,7 @@ export class SerialPortCtrl {
         });
 
         this._currentSerialPort.on("error", (_error) => {
-          this._outputChannel.appendLine("[Error]" + _error.toString());
+          this._outputChannel.appendLine("[Error] " + _error.toString());
         });
       }
     });
@@ -154,7 +156,7 @@ export class SerialPortCtrl {
       }
       this._currentSerialPort.close((err) => {
         if (this._outputChannel) {
-          this._outputChannel.appendLine(`[Done] Closed the serial port ${os.EOL}`);
+          this._outputChannel.appendLine(`[Done] Closed the serial port ${this._currentPort} ${os.EOL}`);
         }
         this._currentSerialPort = null;
         if (err) {
@@ -166,6 +168,8 @@ export class SerialPortCtrl {
     });
   }
   public changeBaudRate(newRate: number): Promise<any> {
+
+    this._outputChannel.appendLine(`[Info] Baud Rate set to ${newRate}`);
     return new Promise((resolve, reject) => {
       this._currentBaudRate = newRate;
       if (!this._currentSerialPort || !this.isActive) {
@@ -182,6 +186,7 @@ export class SerialPortCtrl {
     });
   }
   public changeEnding(newEnding: SerialPortEnding) {
+    this._outputChannel.appendLine(`[Info] Line Endings set to ${SerialPortEnding[newEnding]}`);
     this._ending = newEnding;
   }
 }


### PR DESCRIPTION
…e edited when serial monitor is not active. Expose Arduino: Change line Endings, improve serial monitor messages, changed order of statusbar items, and do not hide them.  Fixes cannot read property settings of null when starting serial monitor when arduino.json is not yet created. Centralized defaults to contstants.ts, and updated README.md to reflect these changes.