### PR TITLE
Add path of libraries into the properties file

### DIFF
--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -592,6 +592,9 @@ Please make sure the folder is not occupied by other procedures .`);
         if (fs.existsSync(toolPath)) {
             result.push(path.normalize(path.join(toolPath, "**")));
         }
+        // path of custom libraries
+        result.push(path.join(this._settings.sketchbookPath, "libraries", "**"));
+
         return result;
     }
 


### PR DESCRIPTION
Custom libraries are currently not "auto scanned" in the c_cpp_properties.json which results in many import/syntax errors for the end users.

Within this PR, I have added the ability for these custom library paths to be imported as well.

I have tested the PR change locally.