### PR TITLE
add windows for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 - '11'
 
 os:
+- windows
 - linux
 - osx
 dist: trusty # using Ubuntu 14.04.5 LTS
@@ -62,7 +63,9 @@ script:
 - gulp tslint
 - gulp genAikey
 - vsce package
-- npm test --silent
+- if [ $TRAVIS_OS_NAME == "linux" ] || [ $TRAVIS_OS_NAME == "osx" ]; then
+    npm test --silent;
+  fi
 
 deploy:
   # deploy to github release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ There are many ways that you can contribute, beyond writing code. The goal of th
 
 If you are interested in writing code to fix issues, first look at the issues with the [help-wanted](https://github.com/Microsoft/vscode-arduino/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) label. They should have the context and code pointers needed to get started. If not, then feel free to ask for some, and we will be happy to provide any guidance you need.
 
+When you are doing code fix, please work against [develop](https://github.com/microsoft/vscode-arduino/tree/develop) branch and also submit pull request to develop branch. Changes will be merged into master branch after production release.
+
 
 
 ## Reporting Issues

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Welcome to the Visual Studio Code extension for **Arduino** <sup>preview</sup> !
 
 ## Prerequisites
 The Arduino IDE is required. Please install it from the [download page](https://www.arduino.cc/en/main/software#download).
-- *Note:* Arduino IDE `1.8.7` has some breaking changes, causing board package and library installation failures. It is recommended to that you install version `1.8.6` or `1.8.8`
 - The supported Arduino IDE versions are `1.6.x` and later.
 - The Windows Store's version of the Arduino IDE is not supported because of the sandbox environment that the application runs in.
+- *Note:* Arduino IDE `1.8.7` has some breaking changes, causing board package and library installation failures.
 
 ## Installation
 Open VS Code and press <kbd>F1</kbd> or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> to open command palette, select **Install Extension** and type `vscode-arduino`.

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -5,6 +5,8 @@
 import * as assert from "assert";
 import * as os from "os";
 import * as vscode from "vscode";
+const impor = require("impor")(__dirname);
+const usbDetectorModule = impor("../src/serialmonitor/usbDetector") as typeof import ("../src/serialmonitor/usbDetector");
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite("Arduino: Extension Tests", () => {
@@ -68,8 +70,7 @@ suite("Arduino: Extension Tests", () => {
         // When running test on osx, the vscode instance is hanging there after tests finished and cause mocha timeout.
         // As a workaround, closing usb-detection process manually would make test window exit normally.
         if (os.platform() !== "linux") {
-            const usbDector = require("node-usb-native").detector;
-            usbDector.stopMonitoring();
+            usbDetectorModule.UsbDetector.getInstance().stopListening();
         }
     });
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -67,7 +67,7 @@ suite("Arduino: Extension Tests", () => {
         });
 
     suiteTeardown(() => {
-        // When running test on osx, the vscode instance is hanging there after tests finished and cause mocha timeout.
+        // When running test on osx or windows, the vscode instance is hanging there after tests finished and cause mocha timeout.
         // As a workaround, closing usb-detection process manually would make test window exit normally.
         if (os.platform() !== "linux") {
             usbDetectorModule.UsbDetector.getInstance().stopListening();


### PR DESCRIPTION
1. Add windows environment to Travis CI.
2. Fix test error for stopping usb detector on windows.
3. Update Contribution guide to tell the code fix flow which is working against develop branch not master branch.
4. Update Readme to remove recommended Arduino IDE version since version 1.8.8 is out of date.