### PR TITLE
Option to use arduino-cli instead of Arduino IDE

### DIFF
--- a/package.json
+++ b/package.json
@@ -442,7 +442,7 @@
       "type": "object",
       "title": "Arduino configuration",
       "properties": {
-        "arduino.isArduinoCli" : {
+        "arduino.useArduinoCli": {
           "type": "boolean",
           "default": false,
           "description": "Arduino-CLI installed instead of more common Arduino GUI"

--- a/package.json
+++ b/package.json
@@ -442,6 +442,11 @@
       "type": "object",
       "title": "Arduino configuration",
       "properties": {
+        "arduino.isArduinoCli" : {
+          "type": "boolean",
+          "default": false,
+          "description": "Arduino-CLI installed instead of more common Arduino GUI"
+        },
         "arduino.path": {
           "type": "string",
           "default": "",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,10 @@
         }
       },
       {
+        "command": "arduino.cliUpload",
+        "title": "Arduino CLI: Upload"
+      },
+      {
         "command": "arduino.uploadUsingProgrammer",
         "title": "Arduino: Upload Using Programmer"
       },

--- a/package.json
+++ b/package.json
@@ -453,7 +453,7 @@
         "arduino.useArduinoCli": {
           "type": "boolean",
           "default": false,
-          "description": "Use Arduino CLI installed instead of Arduino IDE"
+          "markdownDescription": "Use Arduino CLI installed instead of Arduino IDE. `#arduino.path#` must be set, as there is no default path for 'arduino-cli'. (Requires a restart after change)"
         },
         "arduino.path": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,10 @@
         "title": "Arduino: Upload Using Programmer"
       },
       {
+        "command": "arduino.cliUploadUsingProgrammer",
+        "title": "Arduino CLI: Upload Using Programmer"
+      },
+      {
         "command": "arduino.selectProgrammer",
         "title": "Arduino: Select Programmer"
       },

--- a/package.json
+++ b/package.json
@@ -453,7 +453,7 @@
         "arduino.useArduinoCli": {
           "type": "boolean",
           "default": false,
-          "description": "Arduino-CLI installed instead of more common Arduino GUI"
+          "description": "Use Arduino CLI installed instead of Arduino IDE"
         },
         "arduino.path": {
           "type": "string",

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -96,6 +96,7 @@ export class ArduinoApp {
     /**
      * Upload code to selected board
      * @param {bool} [compile=true] - Indicates whether to compile the code when using the CLI to upload
+     * @param {bool} [useProgrammer=false] - Indicate whether a specific programmer should be used
      */
     public async upload(compile: boolean = true, useProgrammer: boolean = false) {
         const dc = DeviceContext.getInstance();
@@ -175,7 +176,7 @@ export class ArduinoApp {
         if (VscodeSettings.getInstance().logLevel === "verbose") {
             args.push("--verbose");
         }
-        if (dc.output) {
+        if (dc.output && compile) {
             const outputPath = path.resolve(ArduinoWorkspace.rootPath, dc.output);
             const dirPath = path.dirname(outputPath);
             if (!util.directoryExistsSync(dirPath)) {

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -289,10 +289,12 @@ export class ArduinoApp {
                 return;
             }
             
-            if (this.isArduinoCli())
+            if (this.isArduinoCli()) {
                 args.push("--build-path", `build.path=${outputPath}`);
-            else
+            }
+            else {
                 args.push("--pref", `build.path=${outputPath}`);
+            }
 
             arduinoChannel.info(`Please see the build logs in Output path: ${outputPath}`);
         } else {

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -140,7 +140,7 @@ export class ArduinoApp {
             }
         }
 
-        const appPath = this.isArduinoCli ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
+        const appPath = this.isArduinoCli() ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
         const args = this.isArduinoCli() ? ["upload", "-b", boardDescriptor] : ["--upload", "--board", boardDescriptor];
         if (dc.port) {
             args.push("--port", dc.port);
@@ -213,7 +213,7 @@ export class ArduinoApp {
         UsbDetector.getInstance().pauseListening();
         await vscode.workspace.saveAll(false);
 
-        const appPath = this.isArduinoCli ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
+        const appPath = this.isArduinoCli() ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
         const args = ["--upload", "--board", boardDescriptor, "--port", dc.port, "--useprogrammer",
             "--pref", "programmer=" + selectProgrammer, appPath];
         if (VscodeSettings.getInstance().logLevel === "verbose") {
@@ -276,7 +276,7 @@ export class ArduinoApp {
             }
         }
 
-        const appPath = this.isArduinoCli ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
+        const appPath = this.isArduinoCli() ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
         const args = this.isArduinoCli() ? ["compile", "-b", boardDescriptor, appPath] : ["--verify", "--board", boardDescriptor, appPath];
         if (VscodeSettings.getInstance().logLevel === "verbose") {
             args.push("--verbose");

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -141,7 +141,7 @@ export class ArduinoApp {
         }
 
         const appPath = path.join(ArduinoWorkspace.rootPath, dc.sketch);
-        const args = ["--upload", "--board", boardDescriptor];
+        const args = this.isArduinoCli() ? ["upload", "-b", boardDescriptor] : ["--upload", "--board", boardDescriptor];
         if (dc.port) {
             args.push("--port", dc.port);
         }
@@ -277,7 +277,7 @@ export class ArduinoApp {
         }
 
         const appPath = path.join(ArduinoWorkspace.rootPath, dc.sketch);
-        const args = ["--verify", "--board", boardDescriptor, appPath];
+        const args = this.isArduinoCli() ? ["compile", "-b", boardDescriptor, appPath] : ["--verify", "--board", boardDescriptor, appPath];
         if (VscodeSettings.getInstance().logLevel === "verbose") {
             args.push("--verbose");
         }
@@ -288,8 +288,12 @@ export class ArduinoApp {
                 Logger.notifyUserError("InvalidOutPutPath", new Error(constants.messages.INVALID_OUTPUT_PATH + outputPath));
                 return;
             }
+            
+            if (this.isArduinoCli())
+                args.push("--build-path", `build.path=${outputPath}`);
+            else
+                args.push("--pref", `build.path=${outputPath}`);
 
-            args.push("--pref", `build.path=${outputPath}`);
             arduinoChannel.info(`Please see the build logs in Output path: ${outputPath}`);
         } else {
             const msg = "Output path is not specified. Unable to reuse previously compiled files. Verify could be slow. See README.";
@@ -733,6 +737,10 @@ Please make sure the folder is not occupied by other procedures .`);
 
     public set programmerManager(value: ProgrammerManager) {
         this._programmerManager = value;
+    }
+
+    private isArduinoCli() {
+        return true;
     }
 
     private getProgrammerString(): string {

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -93,6 +93,9 @@ export class ArduinoApp {
         }
     }
 
+    /**
+     * Upload code
+     */
     public async upload() {
         const dc = DeviceContext.getInstance();
         const boardDescriptor = this.getBoardBuildString();
@@ -140,8 +143,8 @@ export class ArduinoApp {
             }
         }
 
-        const appPath = this.isArduinoCli() ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
-        const args = this.isArduinoCli() ? ["upload", "-b", boardDescriptor] : ["--upload", "--board", boardDescriptor];
+        const appPath = this.useArduinoCli() ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
+        const args = this.useArduinoCli() ? ["upload", "-b", boardDescriptor] : ["--upload", "--board", boardDescriptor];
         if (dc.port) {
             args.push("--port", dc.port);
         }
@@ -213,7 +216,7 @@ export class ArduinoApp {
         UsbDetector.getInstance().pauseListening();
         await vscode.workspace.saveAll(false);
 
-        const appPath = this.isArduinoCli() ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
+        const appPath = this.useArduinoCli() ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
         const args = ["--upload", "--board", boardDescriptor, "--port", dc.port, "--useprogrammer",
             "--pref", "programmer=" + selectProgrammer, appPath];
         if (VscodeSettings.getInstance().logLevel === "verbose") {
@@ -276,8 +279,8 @@ export class ArduinoApp {
             }
         }
 
-        const appPath = this.isArduinoCli() ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
-        const args = this.isArduinoCli() ? ["compile", "-b", boardDescriptor, appPath] : ["--verify", "--board", boardDescriptor, appPath];
+        const appPath = this.useArduinoCli() ?  ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
+        const args = this.useArduinoCli() ? ["compile", "-b", boardDescriptor, appPath] : ["--verify", "--board", boardDescriptor, appPath];
         if (VscodeSettings.getInstance().logLevel === "verbose") {
             args.push("--verbose");
         }
@@ -289,7 +292,7 @@ export class ArduinoApp {
                 return;
             }
 
-            if (this.isArduinoCli()) {
+            if (this.useArduinoCli()) {
                 args.push("--build-path", `build.path=${outputPath}`);
             } else {
                 args.push("--pref", `build.path=${outputPath}`);
@@ -512,7 +515,7 @@ export class ArduinoApp {
             }
         }
         try {
-            this.isArduinoCli() ?
+            this.useArduinoCli() ?
                 await util.spawn(this._settings.commandPath,
                     showOutput ? arduinoChannel.channel : null,
                     ["core", "install", `${packageName}${arch && ":" + arch}${version && "@" + version}`]) :
@@ -561,7 +564,7 @@ export class ArduinoApp {
             arduinoChannel.start(`Install library - ${libName}`);
         }
         try {
-            this.isArduinoCli() ?
+            this.useArduinoCli() ?
             await  util.spawn(this._settings.commandPath,
                 showOutput ? arduinoChannel.channel : null,
                 ["lib", "install", `${libName}${version && "@" + version}`]) :
@@ -760,8 +763,13 @@ export class ArduinoApp {
         this._programmerManager = value;
     }
 
-    private isArduinoCli() {
-        return VscodeSettings.getInstance().isArduinoCli;
+    /**
+     * Checks if the arduino cli is being used
+     * @returns {bool} - true if arduino cli is being use
+     */
+    private useArduinoCli() {
+        return this._settings.useArduinoCli;
+        // return VscodeSettings.getInstance().useArduinoCli;
     }
 
     private getProgrammerString(): string {

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -288,11 +288,10 @@ export class ArduinoApp {
                 Logger.notifyUserError("InvalidOutPutPath", new Error(constants.messages.INVALID_OUTPUT_PATH + outputPath));
                 return;
             }
-            
+
             if (this.isArduinoCli()) {
                 args.push("--build-path", `build.path=${outputPath}`);
-            }
-            else {
+            } else {
                 args.push("--pref", `build.path=${outputPath}`);
             }
 

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -140,7 +140,7 @@ export class ArduinoApp {
             }
         }
 
-        const appPath = path.join(ArduinoWorkspace.rootPath, dc.sketch);
+        const appPath = this.isArduinoCli ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
         const args = this.isArduinoCli() ? ["upload", "-b", boardDescriptor] : ["--upload", "--board", boardDescriptor];
         if (dc.port) {
             args.push("--port", dc.port);
@@ -213,7 +213,7 @@ export class ArduinoApp {
         UsbDetector.getInstance().pauseListening();
         await vscode.workspace.saveAll(false);
 
-        const appPath = path.join(ArduinoWorkspace.rootPath, dc.sketch);
+        const appPath = this.isArduinoCli ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
         const args = ["--upload", "--board", boardDescriptor, "--port", dc.port, "--useprogrammer",
             "--pref", "programmer=" + selectProgrammer, appPath];
         if (VscodeSettings.getInstance().logLevel === "verbose") {
@@ -276,7 +276,7 @@ export class ArduinoApp {
             }
         }
 
-        const appPath = path.join(ArduinoWorkspace.rootPath, dc.sketch);
+        const appPath = this.isArduinoCli ? ArduinoWorkspace.rootPath : path.join(ArduinoWorkspace.rootPath, dc.sketch);
         const args = this.isArduinoCli() ? ["compile", "-b", boardDescriptor, appPath] : ["--verify", "--board", boardDescriptor, appPath];
         if (VscodeSettings.getInstance().logLevel === "verbose") {
             args.push("--verbose");
@@ -740,7 +740,7 @@ Please make sure the folder is not occupied by other procedures .`);
     }
 
     private isArduinoCli() {
-        return true;
+        return VscodeSettings.getInstance().isArduinoCli;
     }
 
     private getProgrammerString(): string {

--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -22,7 +22,7 @@ export interface IArduinoSettings {
     preferencePath: string;
     defaultBaudRate: number;
     preferences: Map<string, string>;
-    isArduinoCli: boolean;
+    useArduinoCli: boolean;
     reloadPreferences(): void;
 }
 
@@ -39,7 +39,7 @@ export class ArduinoSettings implements IArduinoSettings {
 
     private _preferences: Map<string, string>;
 
-    private _isArduinoCli: boolean;
+    private _useArduinoCli: boolean;
 
     public constructor() {
     }
@@ -47,13 +47,13 @@ export class ArduinoSettings implements IArduinoSettings {
     public async initialize() {
         const platform = os.platform();
         this._commandPath = VscodeSettings.getInstance().commandPath;
-        this._isArduinoCli = VscodeSettings.getInstance().isArduinoCli;
+        this._useArduinoCli = VscodeSettings.getInstance().useArduinoCli;
         await this.tryResolveArduinoPath();
         await this.tryGetDefaultBaudRate();
         if (platform === "win32") {
             await this.updateWindowsPath();
             if (this._commandPath === "") {
-                this._isArduinoCli ? this._commandPath = "arduino-cli.exe" : this._commandPath = "arduino_debug.exe";
+                this._useArduinoCli ? this._commandPath = "arduino-cli.exe" : this._commandPath = "arduino_debug.exe";
             }
         } else if (platform === "linux") {
             if (util.directoryExistsSync(path.join(this._arduinoPath, "portable"))) {
@@ -154,8 +154,8 @@ export class ArduinoSettings implements IArduinoSettings {
         return this._preferences;
     }
 
-    public get isArduinoCli() {
-        return this._isArduinoCli;
+    public get useArduinoCli() {
+        return this._useArduinoCli;
     }
 
     public get defaultBaudRate() {

--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -22,6 +22,7 @@ export interface IArduinoSettings {
     preferencePath: string;
     defaultBaudRate: number;
     preferences: Map<string, string>;
+    isArduinoCli: boolean;
     reloadPreferences(): void;
 }
 
@@ -38,12 +39,15 @@ export class ArduinoSettings implements IArduinoSettings {
 
     private _preferences: Map<string, string>;
 
+    private _isArduinoCli : boolean;
+
     public constructor() {
     }
 
     public async initialize() {
         const platform = os.platform();
         this._commandPath = VscodeSettings.getInstance().commandPath;
+        this._isArduinoCli = VscodeSettings.getInstance().isArduinoCli;
         await this.tryResolveArduinoPath();
         await this.tryGetDefaultBaudRate();
         if (platform === "win32") {
@@ -148,6 +152,10 @@ export class ArduinoSettings implements IArduinoSettings {
             this._preferences = util.parseConfigFile(this.preferencePath);
         }
         return this._preferences;
+    }
+
+    public get isArduinoCli() {
+        return this._isArduinoCli;
     }
 
     public get defaultBaudRate() {

--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -39,7 +39,7 @@ export class ArduinoSettings implements IArduinoSettings {
 
     private _preferences: Map<string, string>;
 
-    private _isArduinoCli : boolean;
+    private _isArduinoCli: boolean;
 
     public constructor() {
     }

--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -53,7 +53,7 @@ export class ArduinoSettings implements IArduinoSettings {
         if (platform === "win32") {
             await this.updateWindowsPath();
             if (this._commandPath === "") {
-                this._commandPath = "arduino_debug.exe";
+                this._isArduinoCli ? this._commandPath = "arduino-cli.exe" : this._commandPath = "arduino_debug.exe";
             }
         } else if (platform === "linux") {
             if (util.directoryExistsSync(path.join(this._arduinoPath, "portable"))) {

--- a/src/arduino/programmerManager.ts
+++ b/src/arduino/programmerManager.ts
@@ -58,95 +58,57 @@ export class ProgrammerManager {
         dc.programmer = chosen;
     }
 
+    /**
+     * Gets a specific programmer from the programmers list.
+     * If using the Arduino IDE, adds prefix "adruino:"
+     * @param {ProgrammerList} newProgrammer - a list of the available programmers
+     */
     public getProgrammer(newProgrammer: ProgrammerList) {
-        if (this._settings.useArduinoCli) {
-            switch (newProgrammer) {
-                case ProgrammerList["AVR ISP"]:
-                    this._programmervalue = "avrisp";
-                    break;
-                case ProgrammerList["AVRISP mkII"]:
-                    this._programmervalue = "avrispmkii";
-                    break;
-                case ProgrammerList.USBtinyISP:
-                    this._programmervalue = "usbtinyisp";
-                    break;
-                case ProgrammerList.ArduinoISP:
-                    this._programmervalue = "arduinoisp";
-                    break;
-                case ProgrammerList.USBasp:
-                    this._programmervalue = "usbasp";
-                    break;
-                case ProgrammerList["Parallel Programmer"]:
-                    this._programmervalue = "parallel";
-                    break;
-                case ProgrammerList["Arduino as ISP"]:
-                    this._programmervalue = "arduinoasisp";
-                    break;
-                case ProgrammerList["Arduino Gemma"]:
-                    this._programmervalue = "usbGemma";
-                    break;
-                case ProgrammerList["BusPirate as ISP"]:
-                    this._programmervalue = "buspirate";
-                    break;
-                case ProgrammerList["Atmel STK500 development board"]:
-                    this._programmervalue = "stk500";
-                    break;
-                case ProgrammerList["Atmel JTAGICE3 (ISP mode)"]:
-                    this._programmervalue = "jtag3isp";
-                    break;
-                case ProgrammerList["Atmel JTAGICE3 (JTAG mode)"]:
-                    this._programmervalue = "jtag3";
-                    break;
-                case ProgrammerList["Atmel-ICE (AVR)"]:
-                    this._programmervalue = "atmel_ice";
-                    break;
-                default:
-                    break;
-            }
-        } else {
-            switch (newProgrammer) {
-                case ProgrammerList["AVR ISP"]:
-                    this._programmervalue = "arduino:avrisp";
-                    break;
-                case ProgrammerList["AVRISP mkII"]:
-                    this._programmervalue = "arduino:avrispmkii";
-                    break;
-                case ProgrammerList.USBtinyISP:
-                    this._programmervalue = "arduino:usbtinyisp";
-                    break;
-                case ProgrammerList.ArduinoISP:
-                    this._programmervalue = "arduino:arduinoisp";
-                    break;
-                case ProgrammerList.USBasp:
-                    this._programmervalue = "arduino:usbasp";
-                    break;
-                case ProgrammerList["Parallel Programmer"]:
-                    this._programmervalue = "arduino:parallel";
-                    break;
-                case ProgrammerList["Arduino as ISP"]:
-                    this._programmervalue = "arduino:arduinoasisp";
-                    break;
-                case ProgrammerList["Arduino Gemma"]:
-                    this._programmervalue = "arduino:usbGemma";
-                    break;
-                case ProgrammerList["BusPirate as ISP"]:
-                    this._programmervalue = "arduino:buspirate";
-                    break;
-                case ProgrammerList["Atmel STK500 development board"]:
-                    this._programmervalue = "arduino:stk500";
-                    break;
-                case ProgrammerList["Atmel JTAGICE3 (ISP mode)"]:
-                    this._programmervalue = "arduino:jtag3isp";
-                    break;
-                case ProgrammerList["Atmel JTAGICE3 (JTAG mode)"]:
-                    this._programmervalue = "arduino:jtag3";
-                    break;
-                case ProgrammerList["Atmel-ICE (AVR)"]:
-                    this._programmervalue = "arduino:atmel_ice";
-                    break;
-                default:
-                    break;
-            }
+        let prefix = "";
+        if (!this._settings.useArduinoCli) {
+            prefix = "arduino:"};
+        switch (newProgrammer) {
+            case ProgrammerList["AVR ISP"]:
+                this._programmervalue = prefix + "avrisp";
+                break;
+            case ProgrammerList["AVRISP mkII"]:
+                this._programmervalue = prefix + "avrispmkii";
+                break;
+            case ProgrammerList.USBtinyISP:
+                this._programmervalue = prefix + "usbtinyisp";
+                break;
+            case ProgrammerList.ArduinoISP:
+                this._programmervalue = prefix + "arduinoisp";
+                break;
+            case ProgrammerList.USBasp:
+                this._programmervalue = prefix + "usbasp";
+                break;
+            case ProgrammerList["Parallel Programmer"]:
+                this._programmervalue = prefix + "parallel";
+                break;
+            case ProgrammerList["Arduino as ISP"]:
+                this._programmervalue = prefix + "arduinoasisp";
+                break;
+            case ProgrammerList["Arduino Gemma"]:
+                this._programmervalue = prefix + "usbGemma";
+                break;
+            case ProgrammerList["BusPirate as ISP"]:
+                this._programmervalue = prefix + "buspirate";
+                break;
+            case ProgrammerList["Atmel STK500 development board"]:
+                this._programmervalue = prefix + "stk500";
+                break;
+            case ProgrammerList["Atmel JTAGICE3 (ISP mode)"]:
+                this._programmervalue = prefix + "jtag3isp";
+                break;
+            case ProgrammerList["Atmel JTAGICE3 (JTAG mode)"]:
+                this._programmervalue = prefix + "jtag3";
+                break;
+            case ProgrammerList["Atmel-ICE (AVR)"]:
+                this._programmervalue = prefix + "atmel_ice";
+                break;
+            default:
+                break;
         }
     }
 }

--- a/src/arduino/programmerManager.ts
+++ b/src/arduino/programmerManager.ts
@@ -59,48 +59,94 @@ export class ProgrammerManager {
     }
 
     public getProgrammer(newProgrammer: ProgrammerList) {
-        switch (newProgrammer) {
-            case ProgrammerList["AVR ISP"]:
-                this._programmervalue = "arduino:avrisp";
-                break;
-            case ProgrammerList["AVRISP mkII"]:
-                this._programmervalue = "arduino:avrispmkii";
-                break;
-            case ProgrammerList.USBtinyISP:
-                this._programmervalue = "arduino:usbtinyisp";
-                break;
-            case ProgrammerList.ArduinoISP:
-                this._programmervalue = "arduino:arduinoisp";
-                break;
-            case ProgrammerList.USBasp:
-                this._programmervalue = "arduino:usbasp";
-                break;
-            case ProgrammerList["Parallel Programmer"]:
-                this._programmervalue = "arduino:parallel";
-                break;
-            case ProgrammerList["Arduino as ISP"]:
-                this._programmervalue = "arduino:arduinoasisp";
-                break;
-            case ProgrammerList["Arduino Gemma"]:
-                this._programmervalue = "arduino:usbGemma";
-                break;
-            case ProgrammerList["BusPirate as ISP"]:
-                this._programmervalue = "arduino:buspirate";
-                break;
-            case ProgrammerList["Atmel STK500 development board"]:
-                this._programmervalue = "arduino:stk500";
-                break;
-            case ProgrammerList["Atmel JTAGICE3 (ISP mode)"]:
-                this._programmervalue = "arduino:jtag3isp";
-                break;
-            case ProgrammerList["Atmel JTAGICE3 (JTAG mode)"]:
-                this._programmervalue = "arduino:jtag3";
-                break;
-            case ProgrammerList["Atmel-ICE (AVR)"]:
-                this._programmervalue = "arduino:atmel_ice";
-                break;
-            default:
-                break;
+        if (this._settings.useArduinoCli) {
+            switch (newProgrammer) {
+                case ProgrammerList["AVR ISP"]:
+                    this._programmervalue = "avrisp";
+                    break;
+                case ProgrammerList["AVRISP mkII"]:
+                    this._programmervalue = "avrispmkii";
+                    break;
+                case ProgrammerList.USBtinyISP:
+                    this._programmervalue = "usbtinyisp";
+                    break;
+                case ProgrammerList.ArduinoISP:
+                    this._programmervalue = "arduinoisp";
+                    break;
+                case ProgrammerList.USBasp:
+                    this._programmervalue = "usbasp";
+                    break;
+                case ProgrammerList["Parallel Programmer"]:
+                    this._programmervalue = "parallel";
+                    break;
+                case ProgrammerList["Arduino as ISP"]:
+                    this._programmervalue = "arduinoasisp";
+                    break;
+                case ProgrammerList["Arduino Gemma"]:
+                    this._programmervalue = "usbGemma";
+                    break;
+                case ProgrammerList["BusPirate as ISP"]:
+                    this._programmervalue = "buspirate";
+                    break;
+                case ProgrammerList["Atmel STK500 development board"]:
+                    this._programmervalue = "stk500";
+                    break;
+                case ProgrammerList["Atmel JTAGICE3 (ISP mode)"]:
+                    this._programmervalue = "jtag3isp";
+                    break;
+                case ProgrammerList["Atmel JTAGICE3 (JTAG mode)"]:
+                    this._programmervalue = "jtag3";
+                    break;
+                case ProgrammerList["Atmel-ICE (AVR)"]:
+                    this._programmervalue = "atmel_ice";
+                    break;
+                default:
+                    break;
+            }
+        } else {
+            switch (newProgrammer) {
+                case ProgrammerList["AVR ISP"]:
+                    this._programmervalue = "arduino:avrisp";
+                    break;
+                case ProgrammerList["AVRISP mkII"]:
+                    this._programmervalue = "arduino:avrispmkii";
+                    break;
+                case ProgrammerList.USBtinyISP:
+                    this._programmervalue = "arduino:usbtinyisp";
+                    break;
+                case ProgrammerList.ArduinoISP:
+                    this._programmervalue = "arduino:arduinoisp";
+                    break;
+                case ProgrammerList.USBasp:
+                    this._programmervalue = "arduino:usbasp";
+                    break;
+                case ProgrammerList["Parallel Programmer"]:
+                    this._programmervalue = "arduino:parallel";
+                    break;
+                case ProgrammerList["Arduino as ISP"]:
+                    this._programmervalue = "arduino:arduinoasisp";
+                    break;
+                case ProgrammerList["Arduino Gemma"]:
+                    this._programmervalue = "arduino:usbGemma";
+                    break;
+                case ProgrammerList["BusPirate as ISP"]:
+                    this._programmervalue = "arduino:buspirate";
+                    break;
+                case ProgrammerList["Atmel STK500 development board"]:
+                    this._programmervalue = "arduino:stk500";
+                    break;
+                case ProgrammerList["Atmel JTAGICE3 (ISP mode)"]:
+                    this._programmervalue = "arduino:jtag3isp";
+                    break;
+                case ProgrammerList["Atmel JTAGICE3 (JTAG mode)"]:
+                    this._programmervalue = "arduino:jtag3";
+                    break;
+                case ProgrammerList["Atmel-ICE (AVR)"]:
+                    this._programmervalue = "arduino:atmel_ice";
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }

--- a/src/arduino/vscodeSettings.ts
+++ b/src/arduino/vscodeSettings.ts
@@ -15,7 +15,7 @@ const configKeys = {
     IGNORE_BOARDS: "arduino.ignoreBoards",
     SKIP_HEADER_PROVIDER: "arduino.skipHeaderProvider",
     DEFAULT_BAUD_RATE: "arduino.defaultBaudRate",
-    IS_ARDUINO_CLI: "arduino.isArduinoCli",
+    USE_ARDUINO_CLI: "arduino.useArduinoCli",
 };
 
 export interface IVscodeSettings {
@@ -29,7 +29,7 @@ export interface IVscodeSettings {
     ignoreBoards: string[];
     skipHeaderProvider: boolean;
     defaultBaudRate: number;
-    isArduinoCli: boolean;
+    useArduinoCli: boolean;
     updateAdditionalUrls(urls: string | string[]): void;
 }
 
@@ -85,8 +85,8 @@ export class VscodeSettings implements IVscodeSettings {
         return this.getConfigValue<number>(configKeys.DEFAULT_BAUD_RATE);
     }
 
-    public get isArduinoCli(): boolean {
-        return this.getConfigValue<boolean>(configKeys.IS_ARDUINO_CLI);
+    public get useArduinoCli(): boolean {
+        return this.getConfigValue<boolean>(configKeys.USE_ARDUINO_CLI);
     }
 
     public get skipHeaderProvider(): boolean {

--- a/src/arduino/vscodeSettings.ts
+++ b/src/arduino/vscodeSettings.ts
@@ -15,6 +15,7 @@ const configKeys = {
     IGNORE_BOARDS: "arduino.ignoreBoards",
     SKIP_HEADER_PROVIDER: "arduino.skipHeaderProvider",
     DEFAULT_BAUD_RATE: "arduino.defaultBaudRate",
+    IS_ARDUINO_CLI: "arduino.isArduinoCli",
 };
 
 export interface IVscodeSettings {
@@ -28,6 +29,7 @@ export interface IVscodeSettings {
     ignoreBoards: string[];
     skipHeaderProvider: boolean;
     defaultBaudRate: number;
+    isArduinoCli: boolean;
     updateAdditionalUrls(urls: string | string[]): void;
 }
 
@@ -81,6 +83,10 @@ export class VscodeSettings implements IVscodeSettings {
 
     public get defaultBaudRate(): number {
         return this.getConfigValue<number>(configKeys.DEFAULT_BAUD_RATE);
+    }
+
+    public get isArduinoCli(): boolean {
+        return this.getConfigValue<boolean>(configKeys.IS_ARDUINO_CLI);
     }
 
     public get skipHeaderProvider(): boolean {

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -14,8 +14,8 @@ export function resolveArduinoPath(): string {
     return internalSysLib.resolveArduinoPath();
 }
 
-export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
-    return internalSysLib.validateArduinoPath(arduinoPath, isArduinoCli);
+export function validateArduinoPath(arduinoPath: string, useArduinoCli = false): boolean {
+    return internalSysLib.validateArduinoPath(arduinoPath, useArduinoCli);
 }
 
 export function findFile(fileName: string, cwd: string): string {

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -14,8 +14,8 @@ export function resolveArduinoPath(): string {
     return internalSysLib.resolveArduinoPath();
 }
 
-export function validateArduinoPath(arduinoPath: string): boolean {
-    return internalSysLib.validateArduinoPath(arduinoPath);
+export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
+    return internalSysLib.validateArduinoPath(arduinoPath, isArduinoCli);
 }
 
 export function findFile(fileName: string, cwd: string): string {

--- a/src/common/sys/darwin.ts
+++ b/src/common/sys/darwin.ts
@@ -18,8 +18,8 @@ export function resolveArduinoPath(): string {
     return result || "";
 }
 
-export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
-    return fileExistsSync(path.join(resolveMacArduinoAppPath(arduinoPath), isArduinoCli ? "arduino-cli" : "/Contents/MacOS/Arduino"));
+export function validateArduinoPath(arduinoPath: string, useArduinoCli = false): boolean {
+    return fileExistsSync(path.join(resolveMacArduinoAppPath(arduinoPath), useArduinoCli ? "arduino-cli" : "/Contents/MacOS/Arduino"));
 
 }
 

--- a/src/common/sys/darwin.ts
+++ b/src/common/sys/darwin.ts
@@ -18,7 +18,7 @@ export function resolveArduinoPath(): string {
     return result || "";
 }
 
-export function validateArduinoPath(arduinoPath: string): boolean {
+export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
     return fileExistsSync(path.join(resolveMacArduinoAppPath(arduinoPath), "/Contents/MacOS/Arduino"));
 }
 

--- a/src/common/sys/darwin.ts
+++ b/src/common/sys/darwin.ts
@@ -19,7 +19,8 @@ export function resolveArduinoPath(): string {
 }
 
 export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
-    return fileExistsSync(path.join(resolveMacArduinoAppPath(arduinoPath), "/Contents/MacOS/Arduino"));
+    return fileExistsSync(path.join(resolveMacArduinoAppPath(arduinoPath), isArduinoCli ? "arduino-cli" : "/Contents/MacOS/Arduino"));
+
 }
 
 export function findFile(fileName: string, cwd: string): string {

--- a/src/common/sys/linux.ts
+++ b/src/common/sys/linux.ts
@@ -20,8 +20,8 @@ export function resolveArduinoPath(): string {
     return pathString || "";
 }
 
-export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
-    return fileExistsSync(path.join(arduinoPath, isArduinoCli ? "arduino-cli" : "arduino"));
+export function validateArduinoPath(arduinoPath: string, useArduinoCli = false): boolean {
+    return fileExistsSync(path.join(arduinoPath, useArduinoCli ? "arduino-cli" : "arduino"));
 }
 
 export function findFile(fileName: string, cwd: string): string {

--- a/src/common/sys/linux.ts
+++ b/src/common/sys/linux.ts
@@ -20,8 +20,8 @@ export function resolveArduinoPath(): string {
     return pathString || "";
 }
 
-export function validateArduinoPath(arduinoPath: string): boolean {
-    return fileExistsSync(path.join(arduinoPath, "arduino"));
+export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
+    return fileExistsSync(path.join(arduinoPath, isArduinoCli ? "arduino-cli" : "arduino"));
 }
 
 export function findFile(fileName: string, cwd: string): string {

--- a/src/common/sys/win32.ts
+++ b/src/common/sys/win32.ts
@@ -28,7 +28,8 @@ export async function resolveArduinoPath() {
 }
 
 export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
-    return fileExistsSync(path.join(arduinoPath, "arduino_debug.exe"));
+    return fileExistsSync(path.join(arduinoPath, isArduinoCli ? "arduino-cli.exe" : "arduino_debug.exe"));
+
 }
 
 export function findFile(fileName: string, cwd: string): string {

--- a/src/common/sys/win32.ts
+++ b/src/common/sys/win32.ts
@@ -27,8 +27,8 @@ export async function resolveArduinoPath() {
     return pathString;
 }
 
-export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
-    return fileExistsSync(path.join(arduinoPath, isArduinoCli ? "arduino-cli.exe" : "arduino_debug.exe"));
+export function validateArduinoPath(arduinoPath: string, useArduinoCli = false): boolean {
+    return fileExistsSync(path.join(arduinoPath, useArduinoCli ? "arduino-cli.exe" : "arduino_debug.exe"));
 
 }
 

--- a/src/common/sys/win32.ts
+++ b/src/common/sys/win32.ts
@@ -27,7 +27,7 @@ export async function resolveArduinoPath() {
     return pathString;
 }
 
-export function validateArduinoPath(arduinoPath: string): boolean {
+export function validateArduinoPath(arduinoPath: string, isArduinoCli = false): boolean {
     return fileExistsSync(path.join(arduinoPath, "arduino_debug.exe"));
 }
 

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -200,6 +200,13 @@ export function isArduinoFile(filePath): boolean {
     return fileExistsSync(filePath) && (path.extname(filePath) === ".ino" || path.extname(filePath) === ".pde");
 }
 
+/**
+ * Send a command to arduino
+ * @param {string} command - base command path (either Arduino IDE or CLI)
+ * @param {vscode.OutputChannel} outputChannel - output display channel
+ * @param {string[]} [args=[]] - arguments to pass to the command
+ * @param {any} [options={}] - options and flags for the arguments
+ */
 export function spawn(command: string, outputChannel: vscode.OutputChannel, args: string[] = [], options: any = {}): Thenable<object> {
     return new Promise((resolve, reject) => {
         const stdout = "";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,7 +91,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
             const arduinoPath = arduinoContextModule.default.arduinoApp.settings.arduinoPath;
             const commandPath = arduinoContextModule.default.arduinoApp.settings.commandPath;
-            if (!arduinoPath || !validateArduinoPath(arduinoPath)) { // Pop up vscode User Settings page when cannot resolve arduino path.
+            const isArduinoCli = arduinoContextModule.default.arduinoApp.settings.isArduinoCli;
+            if (!arduinoPath || !validateArduinoPath(arduinoPath, isArduinoCli)) { // Pop up vscode User Settings page when cannot resolve arduino path.
                 Logger.notifyUserError("InvalidArduinoPath", new Error(constants.messages.INVALID_ARDUINO_PATH));
                 vscode.commands.executeCommand("workbench.action.openGlobalSettings");
             } else if (!commandPath || !util.fileExistsSync(commandPath)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,9 +91,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
             const arduinoPath = arduinoContextModule.default.arduinoApp.settings.arduinoPath;
             const commandPath = arduinoContextModule.default.arduinoApp.settings.commandPath;
-            const isArduinoCli = arduinoContextModule.default.arduinoApp.settings.isArduinoCli;
+            const useArduinoCli = arduinoContextModule.default.arduinoApp.settings.useArduinoCli;
             // Pop up vscode User Settings page when cannot resolve arduino path.
-            if (!arduinoPath || !validateArduinoPath(arduinoPath, isArduinoCli)) {
+            if (!arduinoPath || !validateArduinoPath(arduinoPath, useArduinoCli)) {
                 Logger.notifyUserError("InvalidArduinoPath", new Error(constants.messages.INVALID_ARDUINO_PATH));
                 vscode.commands.executeCommand("workbench.action.openGlobalSettings");
             } else if (!commandPath || !util.fileExistsSync(commandPath)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,7 +92,8 @@ export async function activate(context: vscode.ExtensionContext) {
             const arduinoPath = arduinoContextModule.default.arduinoApp.settings.arduinoPath;
             const commandPath = arduinoContextModule.default.arduinoApp.settings.commandPath;
             const isArduinoCli = arduinoContextModule.default.arduinoApp.settings.isArduinoCli;
-            if (!arduinoPath || !validateArduinoPath(arduinoPath, isArduinoCli)) { // Pop up vscode User Settings page when cannot resolve arduino path.
+            // Pop up vscode User Settings page when cannot resolve arduino path.
+            if (!arduinoPath || !validateArduinoPath(arduinoPath, isArduinoCli)) {
                 Logger.notifyUserError("InvalidArduinoPath", new Error(constants.messages.INVALID_ARDUINO_PATH));
                 vscode.commands.executeCommand("workbench.action.openGlobalSettings");
             } else if (!commandPath || !util.fileExistsSync(commandPath)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -197,7 +197,20 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!status.compile) {
             status.compile = "upload";
             try {
-                await arduinoContextModule.default.arduinoApp.uploadUsingProgrammer();
+                await arduinoContextModule.default.arduinoApp.upload(true, true);
+            } catch (ex) {
+            }
+            delete status.compile;
+        }
+    }, () => {
+        return { board: arduinoContextModule.default.boardManager.currentBoard.name };
+    });
+
+    registerArduinoCommand("arduino.cliUploadUsingProgrammer", async () => {
+        if (!status.compile) {
+            status.compile = "cliUpload";
+            try {
+                await arduinoContextModule.default.arduinoApp.upload(false, true);
             } catch (ex) {
             }
             delete status.compile;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,6 +154,24 @@ export async function activate(context: vscode.ExtensionContext) {
         return { board: arduinoContextModule.default.boardManager.currentBoard.name };
     });
 
+    registerArduinoCommand("arduino.cliUpload", async () => {
+        if (!status.compile) {
+            status.compile = "cliUpload";
+            try {
+                await vscode.window.withProgress({
+                    location: vscode.ProgressLocation.Window,
+                    title: "Arduino: Using CLI to upload...",
+                }, async () => {
+                    await arduinoContextModule.default.arduinoApp.upload(false);
+                });
+            } catch (ex) {
+            }
+            delete status.compile;
+        }
+    }, () => {
+        return { board: arduinoContextModule.default.boardManager.currentBoard.name };
+    });
+
     registerArduinoCommand("arduino.setSketchFile", async () => {
         const sketchFileName = deviceContext.sketch;
         const newSketchFileName = await vscode.window.showInputBox({

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -55,6 +55,8 @@ suite("Arduino: Extension Tests", () => {
                     "arduino.loadPackages",
                     "arduino.installBoard",
                     "arduino.setSketchFile",
+                    "arduino.cliUpload",
+                    "arduino.cliUploadUsingProgrammer",
                 ];
 
                 const foundArduinoCommands = commands.filter((value) => {

--- a/test/librarymanager.test.ts
+++ b/test/librarymanager.test.ts
@@ -79,7 +79,7 @@ suite("Arduino: Library Manager.", () => {
                 if (util.directoryExistsSync(libPath)) {
                     done();
                 } else {
-                    done(new Error("AzureIoTHub library install failure, can't find library path :" + libPath));
+                    done(new Error("AzureIoTHub library install failure, can't find library path: " + libPath));
                 }
             });
 


### PR DESCRIPTION
Solves the issue #856 
* Adds a checkbox to the configuration interface to choose between standard Arduino and the CLI version ;
* Is necessary to explicitly set "arduino-cli" in command path;
* the support for Windows and MacOS is not complete.