### PR TITLE
update usb detector

### DIFF
--- a/src/serialmonitor/usbDetector.ts
+++ b/src/serialmonitor/usbDetector.ts
@@ -9,6 +9,8 @@ import { IBoard } from "../arduino/package";
 import { VscodeSettings } from "../arduino/vscodeSettings";
 import ArduinoActivator from "../arduinoActivator";
 import ArduinoContext from "../arduinoContext";
+import { ARDUINO_CONFIG_FILE } from "../common/constants";
+import { ArduinoWorkspace } from "../common/workspace";
 
 import * as util from "../common/util";
 import * as Logger from "../logger/logger";
@@ -75,6 +77,10 @@ export class UsbDetector {
                     SerialMonitor.getInstance().initialize();
                 }
                 let bd = ArduinoContext.boardManager.installedBoards.get(boardKey);
+                const openEditor = vscode.window.activeTextEditor;
+                if (ArduinoWorkspace.rootPath && (
+                    util.fileExistsSync(path.join(ArduinoWorkspace.rootPath, ARDUINO_CONFIG_FILE))
+                    || (openEditor && openEditor.document.fileName.endsWith(".ino")))) {
                 if (!bd) {
                     ArduinoContext.boardManager.updatePackageIndex(deviceDescriptor.indexFile).then((shouldLoadPackageContent) => {
                         const ignoreBoards = VscodeSettings.getInstance().ignoreBoards || [];
@@ -127,6 +133,7 @@ export class UsbDetector {
                     this.switchBoard(bd, deviceDescriptor);
                 }
             }
+        }
         });
         this._usbDetector.startMonitoring();
     }


### PR DESCRIPTION
Fix:
Setting up or switching board config requires `arduino.json` file, and will create it if not exist. But the file is not needed for non-arduino project. 
Update the case to only when it is Arduino project or "*.ino" file actively opened which is the same criteria as Arduino extension activated, usb detector will set up board config and open Arduino examples.