### PR TITLE
suppress sending telemetry of error details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -558,13 +558,14 @@
       }
     },
     "applicationinsights": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.1.tgz",
-      "integrity": "sha1-U0Rrgw/o1dYZ7uKieLMdPSUDCSc=",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
+      "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
       "requires": {
+        "cls-hooked": "^4.2.2",
+        "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "0.2.0",
-        "diagnostic-channel-publishers": "0.2.1",
-        "zone.js": "0.7.6"
+        "diagnostic-channel-publishers": "^0.3.3"
       }
     },
     "aproba": {
@@ -838,6 +839,23 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
+    },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
+    },
+    "async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "requires": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
+      }
     },
     "async-settle": {
       "version": "1.0.0",
@@ -1493,6 +1511,16 @@
         "readable-stream": "^2.3.5"
       }
     },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1635,6 +1663,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "requires": {
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
+      }
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -2019,9 +2056,9 @@
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz",
-      "integrity": "sha1-ji1geottef6IC1SLxYzGvrKIxPM="
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
+      "integrity": "sha512-SZ1zMfFiEabf4Qx0Og9V1gMsRoqz3O+5ENkVcNOfI+SMJ3QhQsdEoKX99r0zvreagXot2parPxmrwwUM/ja8ug=="
     },
     "diff": {
       "version": "3.5.0",
@@ -2105,6 +2142,14 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
       }
     },
     "emoji-regex": {
@@ -7498,6 +7543,11 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -7769,6 +7819,11 @@
       "requires": {
         "figgy-pudding": "^3.5.1"
       }
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -8798,11 +8853,11 @@
       }
     },
     "vscode-extension-telemetry": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.18.tgz",
-      "integrity": "sha512-Vw3Sr+dZwl+c6PlsUwrTtCOJkgrmvS3OUVDQGcmpXWAgq9xGq6as0K4pUx+aGqTjzLAESmWSrs6HlJm6J6Khcg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.6.tgz",
+      "integrity": "sha512-rbzSg7k4NnsCdF4Lz0gI4jl3JLXR0hnlmfFgsY8CSDYhXgdoIxcre8jw5rjkobY0xhSDhbG7xCjP8zxskySJ/g==",
       "requires": {
-        "applicationinsights": "1.0.1"
+        "applicationinsights": "1.7.4"
       }
     },
     "vscode-test": {
@@ -9313,11 +9368,6 @@
           }
         }
       }
-    },
-    "zone.js": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.7.6.tgz",
-      "integrity": "sha1-+7w50+AmHQmG8boGMG6zrrDSIAk="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -583,7 +583,7 @@
     "node-usb-native": "^0.0.13",
     "properties": "^1.2.1",
     "uuid": "^3.0.1",
-    "vscode-extension-telemetry": "0.0.18",
+    "vscode-extension-telemetry": "0.1.6",
     "winreg": "^1.2.3",
     "winston": "^2.3.1"
   }

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -6,6 +6,12 @@ import * as winston from "winston";
 import TelemetryTransport from "./telemetry-transport";
 import UserNotificationTransport from "./user-notification-transport";
 
+export enum LogLevel {
+    info = "info",
+    warn = "warn",
+    error = "error",
+}
+
 function FilterErrorPath(line: string): string {
     if (line) {
         const values: string[] = line.split("/out/");
@@ -21,9 +27,9 @@ function FilterErrorPath(line: string): string {
 export function configure(context: vscode.ExtensionContext) {
     winston.configure({
         transports: [
-            new (winston.transports.File)({ level: "warn", filename: context.asAbsolutePath("arduino.log") }),
-            new TelemetryTransport({ level: "info", context }),
-            new UserNotificationTransport({ level: "info" }),
+            new (winston.transports.File)({ level: LogLevel.warn, filename: context.asAbsolutePath("arduino.log") }),
+            new TelemetryTransport({ level: LogLevel.info, context }),
+            new UserNotificationTransport({ level: LogLevel.info }),
         ],
     });
 }
@@ -54,7 +60,7 @@ export function silly(message: string, metadata?: any) {
 
 export function traceUserData(message: string, metadata?: any) {
     // use `info` as the log level and add a special flag in metadata
-    winston.log("info", message, { ...metadata, telemetry: true });
+    winston.log(LogLevel.info, message, { ...metadata, telemetry: true });
 }
 
 function traceErrorOrWarning(level: string, message: string, error: Error, metadata?: any) {
@@ -68,15 +74,15 @@ function traceErrorOrWarning(level: string, message: string, error: Error, metad
             firstLine = FilterErrorPath(firstLine ? firstLine.replace(/\\/g, "/") : "");
         }
     }
-    winston.log(level, "error", { ...metadata, message: error.message, errorLine: firstLine, telemetry: true });
+    winston.log(level, message, { ...metadata, message: error.message, errorLine: firstLine, telemetry: true });
 }
 
 export function traceError(message: string, error: Error, metadata?: any) {
-    traceErrorOrWarning("error", message, error, metadata);
+    traceErrorOrWarning(LogLevel.error, message, error, metadata);
 }
 
 export function traceWarning(message: string, error: Error, metadata?: any) {
-    traceErrorOrWarning("warn", message, error, metadata);
+    traceErrorOrWarning(LogLevel.warn, message, error, metadata);
 }
 
 export function notifyAndThrowUserError(errorCode: string, error: Error, message?: string) {

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -7,9 +7,9 @@ import TelemetryTransport from "./telemetry-transport";
 import UserNotificationTransport from "./user-notification-transport";
 
 export enum LogLevel {
-    info = "info",
-    warn = "warn",
-    error = "error",
+    Info = "info",
+    Warn = "warn",
+    Error = "error",
 }
 
 function FilterErrorPath(line: string): string {
@@ -27,9 +27,9 @@ function FilterErrorPath(line: string): string {
 export function configure(context: vscode.ExtensionContext) {
     winston.configure({
         transports: [
-            new (winston.transports.File)({ level: LogLevel.warn, filename: context.asAbsolutePath("arduino.log") }),
-            new TelemetryTransport({ level: LogLevel.info, context }),
-            new UserNotificationTransport({ level: LogLevel.info }),
+            new (winston.transports.File)({ level: LogLevel.Warn, filename: context.asAbsolutePath("arduino.log") }),
+            new TelemetryTransport({ level: LogLevel.Info, context }),
+            new UserNotificationTransport({ level: LogLevel.Info }),
         ],
     });
 }
@@ -60,7 +60,7 @@ export function silly(message: string, metadata?: any) {
 
 export function traceUserData(message: string, metadata?: any) {
     // use `info` as the log level and add a special flag in metadata
-    winston.log(LogLevel.info, message, { ...metadata, telemetry: true });
+    winston.log(LogLevel.Info, message, { ...metadata, telemetry: true });
 }
 
 function traceErrorOrWarning(level: string, message: string, error: Error, metadata?: any) {
@@ -78,11 +78,11 @@ function traceErrorOrWarning(level: string, message: string, error: Error, metad
 }
 
 export function traceError(message: string, error: Error, metadata?: any) {
-    traceErrorOrWarning(LogLevel.error, message, error, metadata);
+    traceErrorOrWarning(LogLevel.Error, message, error, metadata);
 }
 
 export function traceWarning(message: string, error: Error, metadata?: any) {
-    traceErrorOrWarning(LogLevel.warn, message, error, metadata);
+    traceErrorOrWarning(LogLevel.Warn, message, error, metadata);
 }
 
 export function notifyAndThrowUserError(errorCode: string, error: Error, message?: string) {

--- a/src/logger/telemetry-transport.ts
+++ b/src/logger/telemetry-transport.ts
@@ -39,7 +39,7 @@ export class TelemetryTransport extends winston.Transport {
             winston.error("Failed to initialize telemetry due to no aiKey in package.json.");
             return;
         }
-        this.reporter = new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+        this.reporter = new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey, true);
     }
 
     protected log(level: string, message: string, metadata?: any, callback?: (arg1, arg2) => void) {
@@ -60,7 +60,11 @@ export class TelemetryTransport extends winston.Transport {
                         }
                     }
                 }
-                this.reporter.sendTelemetryEvent(message, properties, measures);
+                if (level === "info") {
+                    this.reporter.sendTelemetryEvent(message, properties, measures);
+                } else {
+                    this.reporter.sendTelemetryErrorEvent(message, properties, measures, ["message", "notification", "errorLine"]);
+                }
             } catch (telemetryErr) {
                 // If sending telemetry event fails ignore it so it won"t break the extension
                 winston.error("Failed to send telemetry event. error: " + telemetryErr);

--- a/src/logger/telemetry-transport.ts
+++ b/src/logger/telemetry-transport.ts
@@ -4,6 +4,7 @@
 import * as vscode from "vscode";
 import TelemetryReporter from "vscode-extension-telemetry";
 import * as winston from "winston";
+import { LogLevel } from "./logger";
 interface IPackageInfo {
     name: string;
     version: string;
@@ -60,7 +61,7 @@ export class TelemetryTransport extends winston.Transport {
                         }
                     }
                 }
-                if (level === "info") {
+                if (level === LogLevel.info) {
                     this.reporter.sendTelemetryEvent(message, properties, measures);
                 } else {
                     this.reporter.sendTelemetryErrorEvent(message, properties, measures, ["message", "notification", "errorLine"]);

--- a/src/logger/telemetry-transport.ts
+++ b/src/logger/telemetry-transport.ts
@@ -61,7 +61,7 @@ export class TelemetryTransport extends winston.Transport {
                         }
                     }
                 }
-                if (level === LogLevel.info) {
+                if (level === LogLevel.Info) {
                     this.reporter.sendTelemetryEvent(message, properties, measures);
                 } else {
                     this.reporter.sendTelemetryErrorEvent(message, properties, measures, ["message", "notification", "errorLine"]);

--- a/src/logger/user-notification-transport.ts
+++ b/src/logger/user-notification-transport.ts
@@ -14,9 +14,9 @@ export default class UserNotificationTransport extends winston.Transport {
     protected log(level: string, message: string, metadata?: any, callback?: (arg1, arg2) => void) {
         if (metadata && metadata.showUser) {
             const notification = (metadata && metadata.notification) ? metadata.notification : message;
-            if (level === LogLevel.warn) {
+            if (level === LogLevel.Warn) {
                 vscode.window.showWarningMessage(notification);
-            } else if (level === LogLevel.error) {
+            } else if (level === LogLevel.Error) {
                 vscode.window.showErrorMessage(notification);
             } else {
                 winston.error(`Invalid error level '${level}' for user notification.`);

--- a/src/logger/user-notification-transport.ts
+++ b/src/logger/user-notification-transport.ts
@@ -3,6 +3,7 @@
 
 import * as vscode from "vscode";
 import * as winston from "winston";
+import { LogLevel } from "./logger";
 
 export default class UserNotificationTransport extends winston.Transport {
 
@@ -13,9 +14,9 @@ export default class UserNotificationTransport extends winston.Transport {
     protected log(level: string, message: string, metadata?: any, callback?: (arg1, arg2) => void) {
         if (metadata && metadata.showUser) {
             const notification = (metadata && metadata.notification) ? metadata.notification : message;
-            if (level === "warn") {
+            if (level === LogLevel.warn) {
                 vscode.window.showWarningMessage(notification);
-            } else if (level === "error") {
+            } else if (level === LogLevel.error) {
                 vscode.window.showErrorMessage(notification);
             } else {
                 winston.error(`Invalid error level '${level}' for user notification.`);


### PR DESCRIPTION
1.update dependency "vscode-extension-telemetry" to version 0.1.6
2. set firstParty = true for TelemetryReporter.
3. use sendTelemetryErrorEvent to suppress sending telemetry of error details.
4. update name of telemetry with error from "error" to predefined message.