### PR TITLE
fix: serial monitor keeps esp devices in flash mode

### DIFF
--- a/src/serialmonitor/serialportctrl.ts
+++ b/src/serialmonitor/serialportctrl.ts
@@ -64,7 +64,7 @@ export class SerialPortCtrl {
           });
         });
       } else {
-        this._currentSerialPort = new SerialPortCtrl.serialport(this._currentPort, { baudRate: this._currentBaudRate });
+        this._currentSerialPort = new SerialPortCtrl.serialport(this._currentPort, { baudRate: this._currentBaudRate, hupcl: false });
         this._outputChannel.show();
         this._currentSerialPort.on("open", () => {
           if (VscodeSettings.getInstance().disableTestingOpen) {


### PR DESCRIPTION
fix: https://github.com/microsoft/vscode-arduino/issues/1015
Root cause: the serialport lib we used causes the issue, see [serialport issue](https://github.com/serialport/node-serialport/issues/1854) and [hupcl](https://github.com/serialport/node-serialport/issues/1678). 
workaround: [link](https://github.com/serialport/node-serialport/issues/1854#issuecomment-496887057).