### PR TITLE
Unify verify, upload, and uploadUsingProgrammer to a single code path

### DIFF
--- a/src/debug/configurationProvider.ts
+++ b/src/debug/configurationProvider.ts
@@ -4,7 +4,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 
-import { ArduinoApp } from "../arduino/arduino";
+import { BuildMode } from "../arduino/arduino";
 import ArduinoActivator from "../arduinoActivator";
 import ArduinoContext from "../arduinoContext";
 
@@ -136,7 +136,7 @@ export class ArduinoDebugConfigurationProvider implements vscode.DebugConfigurat
             config.program = path.join(ArduinoWorkspace.rootPath, outputFolder, `${path.basename(dc.sketch)}.elf`);
 
             // always compile elf to make sure debug the right elf
-            if (!await ArduinoContext.arduinoApp.verify(outputFolder)) {
+            if (!await ArduinoContext.arduinoApp.buildSketch(BuildMode.Verify, outputFolder)) {
                 vscode.window.showErrorMessage("Failure to verify the program, please check output for details.");
                 return false;
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,7 +122,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     location: vscode.ProgressLocation.Window,
                     title: "Arduino: Verifying...",
                 }, async () => {
-                    await arduinoContextModule.default.arduinoApp.verify();
+                    await arduinoContextModule.default.arduinoApp.buildSketch(BuildMode.Verify);
                 });
             } catch (ex) {
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ const completionProviderModule = impor("./langService/completionProvider") as ty
 import * as Logger from "./logger/logger";
 const nsatModule =
     impor("./nsat") as typeof import ("./nsat");
+import { BuildMode } from "./arduino/arduino";
 import { SerialMonitor } from "./serialmonitor/serialMonitor";
 const usbDetectorModule = impor("./serialmonitor/usbDetector") as typeof import ("./serialmonitor/usbDetector");
 
@@ -142,7 +143,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     location: vscode.ProgressLocation.Window,
                     title: "Arduino: Uploading...",
                 }, async () => {
-                    await arduinoContextModule.default.arduinoApp.upload();
+                    await arduinoContextModule.default.arduinoApp.buildSketch(BuildMode.Upload);
                 });
             } catch (ex) {
             }
@@ -177,7 +178,7 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!status.compile) {
             status.compile = "upload";
             try {
-                await arduinoContextModule.default.arduinoApp.uploadUsingProgrammer();
+                await arduinoContextModule.default.arduinoApp.buildSketch(BuildMode.UploadUsingProgrammer);
             } catch (ex) {
             }
             delete status.compile;


### PR DESCRIPTION
Merge these three functions into a single code path.   This reduces maintainence & bugs that resulting from minor variances between the 3 paths.

- Fixes bug that prebuild command not called for uploadUsingProgammer (#941)
- Addresses several code paths where serial monitor & usb detection would not be restored after being disabled (#1060)
