### PR TITLE
Fix empty board and examples list

### DIFF
--- a/src/views/app/components/BoardConfig.tsx
+++ b/src/views/app/components/BoardConfig.tsx
@@ -35,7 +35,7 @@ class BoardConfig extends React.Component<IBoardConfigProps, React.Props<any>> {
         this.state = {};
     }
 
-    public UNSAFE_componentWillMount() {
+    public componentWillMount() {
         this.props.loadInstalledBoards();
         this.props.loadConfigItems();
     }

--- a/src/views/app/components/BoardManager.tsx
+++ b/src/views/app/components/BoardManager.tsx
@@ -66,7 +66,7 @@ class BoardManager extends React.Component<IBoardManagerProps, IBoardManagerStat
         this.typeUpdate = this.typeUpdate.bind(this);
     }
 
-    public UNSAFE_componentWillMount() {
+    public componentWillMount() {
         this.props.loadBoardPackages(false);
     }
 

--- a/src/views/app/components/ExampleTreeView.tsx
+++ b/src/views/app/components/ExampleTreeView.tsx
@@ -39,7 +39,7 @@ class ExampleTreeView extends React.Component<IExampleViewProps, IExampleViewSta
         this.onExpand = this.onExpand.bind(this);
     }
 
-    public UNSAFE_componentWillMount() {
+    public componentWillMount() {
         this.props.loadExamples();
     }
 

--- a/src/views/app/components/LibraryManager.tsx
+++ b/src/views/app/components/LibraryManager.tsx
@@ -80,7 +80,7 @@ class LibraryManager extends React.Component<ILibraryManagerProps, ILibraryManag
         this.handleCheck = this.handleCheck.bind(this);
     }
 
-    public UNSAFE_componentWillMount() {
+    public componentWillMount() {
         this.props.loadLibraries(false);
     }
 


### PR DESCRIPTION
This project is still running on react 15, and these `UNSAFE_*`-lifecycle aliases where not introduced until 16.3, hence they are never called.

fixes #1163, fixes #1360, fixes #1363, fixes #1361, fixes #1372