### PR TITLE
Fix eslint parsing for enums

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -19,6 +19,6 @@ plugins:
   - '@typescript-eslint'
 rules: {
   "no-empty": ["error", { "allowEmptyCatch": true }],
-  "no-unused-vars": ["error", { "args": "none" }]
+  "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }]
 }
 

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -27,8 +27,6 @@ import { SerialMonitor } from "../serialmonitor/serialMonitor";
 import { UsbDetector } from "../serialmonitor/usbDetector";
 import { ProgrammerManager } from "./programmerManager";
 
-// Not sure why eslint fails to detect usage of this enum, so disable checking.
-/* eslint-disable no-unused-vars */
 /**
  * Supported build modes. For further explanation see the documentation
  * of ArduinoApp.build().
@@ -42,7 +40,6 @@ export enum BuildMode {
     UploadProgrammer = "Uploading (programmer)",
     CliUploadProgrammer = "Uploading (programmer) using Arduino CLI",
 }
-/* eslint-enable no-unused-vars */
 
 /**
  * Represent an Arduino application based on the official Arduino IDE.

--- a/src/arduino/intellisense.ts
+++ b/src/arduino/intellisense.ts
@@ -146,7 +146,6 @@ function makeCompilerParserEngines(dc: DeviceContext) {
 }
 
 // Not sure why eslint fails to detect usage of these enums, so disable checking.
-/* eslint-disable no-unused-vars */
 /**
  * Possible states of AnalysisManager's state machine.
  */
@@ -189,7 +188,6 @@ enum AnalysisEvent {
      */
     AnalysisBuildDone,
 }
-/* eslint-enable no-unused-vars */
 
 /**
  * This class manages analysis builds for the automatic IntelliSense

--- a/src/arduino/package.ts
+++ b/src/arduino/package.ts
@@ -152,8 +152,6 @@ export interface IBoardConfigItem {
     options: IBoardConfigOption[];
 }
 
-// Not sure why eslint fails to detect usage of this enum, so disable checking.
-/* eslint-disable no-unused-vars */
 /**
  * Return values of calls to IBoard.loadConfig() and IBoard.updateConfig().
  */
@@ -182,7 +180,6 @@ export enum BoardConfigResult {
      */
     InvalidFormat,
 }
-/* eslint-enable no-unused-vars */
 
 /**
  * Interface for classes that represent an Arduino supported board.

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -10,13 +10,10 @@ export const CPP_CONFIG_FILE = path.join(".vscode", "c_cpp_properties.json");
 /** The name of the intellisense configuration managed by vscode-arduino. */
 export const C_CPP_PROPERTIES_CONFIG_NAME = "Arduino";
 
-// Not sure why eslint fails to detect usage of this enum, so disable checking.
-/* eslint-disable no-unused-vars */
 export enum LogLevel {
     Info = "info",
     Verbose = "verbose",
 }
-/* eslint-enable no-unused-vars */
 
 export const ARDUINO_MODE: vscode.DocumentSelector = [
     { language: "cpp", scheme: "file" },

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -6,14 +6,11 @@ import * as winston from "winston";
 import TelemetryTransport from "./telemetry-transport";
 import UserNotificationTransport from "./user-notification-transport";
 
-// Not sure why eslint fails to detect usage of this enum, so disable checking.
-/* eslint-disable no-unused-vars */
 export enum LogLevel {
     Info = "info",
     Warn = "warn",
     Error = "error",
 }
-/* eslint-enable no-unused-vars */
 
 function FilterErrorPath(line: string): string {
     if (line) {


### PR DESCRIPTION
Eslint will requires a typescript specialized version of the no-unused-vars rule in order to properly understand the use of enums. 