### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: get node
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 11.x
       - name: linux setup
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -46,7 +46,7 @@ jobs:
       - name: preinstall 
         run: | 
           npm install -g node-gyp
-          npm install -g vsce
+          npm install -g vsce@"^1.0.0"
           npm install -g gulp
       - name: install
         run: npm install
@@ -73,7 +73,7 @@ jobs:
     - name: get node
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 11.x
     - name: linux setup
       run: |
         export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0
@@ -85,7 +85,7 @@ jobs:
     - name: preinstall 
       run: | 
         npm install -g node-gyp
-        npm install -g vsce
+        npm install -g vsce@"^1.0.0"
         npm install -g gulp
     - name: install
       run: npm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: get node
         uses: actions/setup-node@v1
         with:
-          node-version: 11.x
+          node-version: 16.x
       - name: linux setup
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -73,7 +73,7 @@ jobs:
     - name: get node
       uses: actions/setup-node@v1
       with:
-        node-version: 11.x
+        node-version: 16.x
     - name: linux setup
       run: |
         export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0


### PR DESCRIPTION
This is a workaround to get CI running again. Version 2 of VSCE only supports Node 14+, and we're stuck on ancient Node 11 for CI. Ideally we update the Node version used in CI, but that will require more time than I have right now to make sure all the dependencies continue to work with that version. A blind update to Node 16 caused problems with node-gyp.