### PR TITLE
 Remove deploy and add Windows test to GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,24 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Node 14 matches the version of Node used by VS Code when this was
+      # written, but it should be updated when VS Code updates its Node version.
+      # Node needs to be installed before OS-specific setup so that we can run
+      # the hash verification script.
+      - name: Use Node 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+
       - name: Windows setup
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
           curl -LO https://downloads.arduino.cc/arduino-1.8.19-windows.zip
+          node build/checkHash.js arduino-1.8.19-windows.zip `
+          c704a821089eab2588f1deae775916219b1517febd1dd574ff29958dca873945
           7z x arduino-1.8.19-windows.zip -o"$Env:TEMP\arduino-ide"
           echo "$Env:TEMP\arduino-ide\arduino-1.8.19" | Out-File -FilePath $env:GITHUB_PATH -Append
       - name: Linux setup
@@ -36,6 +50,8 @@ jobs:
           export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0
           sleep 3
           wget https://downloads.arduino.cc/arduino-1.8.19-linux64.tar.xz -P /home/$USER
+          node build/checkHash.js /home/$USER/arduino-1.8.19-linux64.tar.xz \
+          eb68bddc1d1c0120be2fca1350a03ee34531cf37f51847b21210b6e70545bc9b
           tar -xvf /home/$USER/arduino-1.8.19-linux64.tar.xz -C /home/$USER/
           sudo ln -s /home/$USER/arduino-1.8.19/arduino /usr/bin/arduino
           sudo apt-get update
@@ -46,15 +62,6 @@ jobs:
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
           brew install arduino --cask
 
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      # Node 14 matches the version of Node used by VS Code when this was
-      # written, but it should be updated when VS Code updates its Node version.
-      - name: Use Node 14.x
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
       # Windows agents already have gulp installed.
       - name: Install gulp
         if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,8 @@
-name: CI-Tests
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: CI
+
 on:
   push:
     branches:
@@ -11,110 +15,66 @@ on:
       - master
       - dev
 
-
 jobs:
   build:
-    runs-on: ${{ matrix.os }} 
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-    
+
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: get node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 11.x
-      - name: linux setup
+      - name: Windows setup
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          curl -LO https://downloads.arduino.cc/arduino-1.8.19-windows.zip
+          7z x arduino-1.8.19-windows.zip -o"$Env:TEMP\arduino-ide"
+          echo "$Env:TEMP\arduino-ide\arduino-1.8.19" | Out-File -FilePath $env:GITHUB_PATH -Append
+      - name: Linux setup
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0
           sleep 3
-          wget https://downloads.arduino.cc/arduino-1.8.2-linux64.tar.xz -P /home/$USER
-          tar -xvf /home/$USER/arduino-1.8.2-linux64.tar.xz -C /home/$USER/
-          sudo ln -s /home/$USER/arduino-1.8.2/arduino /usr/bin/arduino
+          wget https://downloads.arduino.cc/arduino-1.8.19-linux64.tar.xz -P /home/$USER
+          tar -xvf /home/$USER/arduino-1.8.19-linux64.tar.xz -C /home/$USER/
+          sudo ln -s /home/$USER/arduino-1.8.19/arduino /usr/bin/arduino
           sudo apt-get update
-          sudo apt-get install g++-multilib
-          sudo apt-get install -y build-essential
-          sudo apt-get install libudev-dev
-      - name: macos setup
+          sudo apt-get install -y g++-multilib build-essential libudev-dev
+      - name: macOS setup
         if: ${{ matrix.os == 'macos-latest' }}
-        run: | 
+        run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
           brew install arduino --cask
-      - name: preinstall 
-        run: | 
-          npm install -g node-gyp
-          npm install -g vsce@"^1.0.0"
-          npm install -g gulp
-      - name: install
-        run: npm install
-      - name: scripts
-        run: |
-          gulp tslint
-          vsce package
-      - name: run tests
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Node 14 matches the version of Node used by VS Code when this was
+      # written, but it should be updated when VS Code updates its Node version.
+      - name: Use Node 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      # Windows agents already have gulp installed.
+      - name: Install gulp
         if: ${{ matrix.os != 'windows-latest' }}
+        run: npm install --global gulp
+      - name: Install global dependencies
+        run: npm install --global node-gyp vsce
+      - name: Install project dependencies
+        run: npm install
+
+      - name: Check for linting errors
+        run: gulp tslint
+      - name: Build and pack extension
+        run: vsce package --out vscode-arduino.vsix
+      - name: Publish extension VSIX as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: VS Code extension VSIX (${{ matrix.os }})
+          path: vscode-arduino.vsix
+
+      - name: Run tests
         uses: GabrielBB/xvfb-action@v1
         with:
           run: npm test --silent
-  
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment: vsix-publishing
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    steps:
-    - run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-    - run: echo ${{env.VERSION}}
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: get node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 11.x
-    - name: linux setup
-      run: |
-        export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0
-        sleep 3
-        sudo apt-get update
-        sudo apt-get install g++-multilib
-        sudo apt-get install -y build-essential
-        sudo apt-get install libudev-dev
-    - name: preinstall 
-      run: | 
-        npm install -g node-gyp
-        npm install -g vsce@"^1.0.0"
-        npm install -g gulp
-    - name: install
-      run: npm install
-    - name: scripts
-      run: |
-        gulp tslint
-        gulp genAikey
-        vsce package
-    - name: upload .vsix to github tag
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.OAUTH_TOKEN }}
-        file: ${{github.workspace}}/vscode-arduino*.vsix
-        tag: ${{ github.ref }}
-        overwrite: true
-        file_glob: true
-    - name: check for production tag
-      id: check-version
-      run: |
-        if [[ ${{ env.VERSION }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo ::set-output name=ISPRODUCTION::true
-        fi
-    # Skip attempting to publish for now, because I can't figure out how to
-    # generate a valid VSCE_TOKEN. Instead we can manually publish by uploading
-    # the release build artifact to the extension publisher site.
-    - name: publish
-      if: false && steps.check-version.outputs.ISPRODUCTION == 'true'
-      env:
-        PROD_AIKEY: ${{ secrets.PROD_AIKEY }}
-      run: | 
-        gulp genAikey
-        vsce publish -p ${{ secrets.VSCE_TOKEN }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,10 +61,8 @@ steps:
   - script: curl -LO https://downloads.arduino.cc/arduino-1.8.19-windows.zip
     displayName: Download Arduino IDE
   - script: >-
-      node --eval "process.exit(require('crypto').createHash('sha256').update(
-      require('fs').readFileSync('arduino-1.8.19-windows.zip')).digest('hex')
-      == 'c704a821089eab2588f1deae775916219b1517febd1dd574ff29958dca873945'
-      ? 0 : 1)"
+      node build/checkHash.js arduino-1.8.19-windows.zip
+      c704a821089eab2588f1deae775916219b1517febd1dd574ff29958dca873945
     displayName: Verify Arduino IDE
   - task: ExtractFiles@1
     displayName: Extract Arduino IDE

--- a/build/checkHash.js
+++ b/build/checkHash.js
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Usage
+//   $ node checkHash.js myfile.zip c704...3945
+// Returns with an exit code of zero if and only if the SHA-256 hash of the
+// given file matches the expected hash.
+
+const path = process.argv[2];
+const expected = process.argv[3];
+const data = require('fs').readFileSync(path);
+const hash = require('crypto').createHash('sha256').update(data).digest('hex');
+if (hash !== expected) {
+    console.error(
+        `Expected SHA-256 of "${path}" to be ${expected} but found ${hash}.`);
+    process.exit(1);
+}


### PR DESCRIPTION
Because the ADO pipeline now handles creation of a GH release, we can simplify the GH actions to just provide quick build and test feedback across all platforms. It's worth keeping this on GH so that external contributors can inspect the build logs, which is impossible with ADO (by design).