### PR TITLE
Mark serial monitor as executable on Mac and Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,6 +115,8 @@ steps:
       includeRootFolder: false
       archiveType: zip
       archiveFile: $(Build.StagingDirectory)\vscode-arduino.vsix
+  - script: python .\build\markExecutableFiles.py
+    displayName: Make serial monitor executable
   - task: MSBuild@1
     displayName: Sign VSIX
     inputs:

--- a/build/markExecutableFiles.py
+++ b/build/markExecutableFiles.py
@@ -1,0 +1,31 @@
+import os
+import zipfile
+
+input_archive_path = f"{os.getenv('BUILD_STAGINGDIRECTORY')})/vscode-arduino.vsix"
+output_archive_path = f"{os.getenv('BUILD_STAGINGDIRECTORY')})/vscode-arduino-out.vsix"
+
+filenames = [
+    "extension/out/serial-monitor-cli/darwin/main",
+    "extension/out/serial-monitor-cli/linux/main"
+]
+
+input_archive = zipfile.ZipFile(input_archive_path, 'r')
+output_archive = zipfile.ZipFile(output_archive_path, 'w')
+
+executable_count = 0
+for info in input_archive.infolist():
+    data = input_archive.read(info)
+    if info.filename in filenames:
+        # Magic number from from https://stackoverflow.com/a/48435482
+        info.external_attr = 0o100755 << 16
+        executable_count += 1
+    output_archive.writestr(info, data)
+
+if executable_count != len(filenames):
+    raise Exception(f'Expected to find {len(filenames)} executables but only found {executable_count}')
+
+input_archive.close()
+output_archive.close()
+
+os.replace(output_archive_path, input_archive_path)
+os.remove(output_archive_path)


### PR DESCRIPTION
The serial monitor broke on Mac and Linux in v0.4.9 (#1418) for two reasons. One is an issue with extensionless files during VSIX signing, which is temporarily resolved by e0f29b8cf79c9bc3649c42cea4b945254a537af9. The other is because we are now producing the official build on a Windows machine, which is removing the Linux executable bits from the serial monitor executables in the final VSIX. This script manually recreates the archive while setting the appropriate bits on the files that need them.