### PR TITLE
Add option for printing timestamp before each line of Serial Monitor output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,8 @@ name: CI
 on:
   push:
     branches:
-      - "*"
+      - main
+      - release
     tags:
       - v*
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,7 @@ name: CI
 on:
   push:
     branches:
-      - main
-      - release
+      - "*"
     tags:
       - v*
   pull_request:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This extension provides several commands in the Command Palette (<kbd>F1</kbd> o
 | `arduino.disableTestingOpen` | Enable/disable automatic sending of a test message to the serial port for checking the open status. The default value is `false` (a test message will be sent). |
 | `arduino.skipHeaderProvider` | Enable/disable the extension providing completion items for headers. This functionality is included in newer versions of the C++ extension. The default value is `false`.|
 | `arduino.defaultBaudRate` | Default baud rate for the serial port monitor. The default value is 115200. Supported values are 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400 and 250000 |
-| `arduino.defaultTimestampFormat` | Default format of timestamp added before each line of Serial Monitor output. List of all possible formats: https://strftime.org. |
+| `arduino.defaultTimestampFormat` | Format of timestamp printed before each line of Serial Monitor output. You can find list of all available placeholders [here](https://strftime.org). |
 | `arduino.disableIntelliSenseAutoGen` | When `true` vscode-arduino will not auto-generate an IntelliSense configuration (i.e. `.vscode/c_cpp_properties.json`) by analyzing Arduino's compiler output. |
 
 The following Visual Studio Code settings are available for the Arduino extension. These can be set in global user preferences <kbd>Ctrl</kbd> + <kbd>,</kbd> or workspace settings (`.vscode/settings.json`). The latter overrides the former.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This extension provides several commands in the Command Palette (<kbd>F1</kbd> o
 - **Arduino: Board Manager**: Manage packages for boards. You can add 3rd party Arduino board by configuring `Additional Board Manager URLs` in the board manager.
 - **Arduino: Change Baud Rate**: Change the baud rate of the selected serial port.
 - **Arduino: Change Board Type**: Change board type or platform.
+- **Arduino: Change Timestamp Format**: Change format of timestamp printed before each line of Serial Monitor output.
 - **Arduino: Close Serial Monitor**: Stop the serial monitor and release the serial port.
 - **Arduino: Examples**: Show list of examples.
 - **Arduino: Initialize**: Scaffold a VS Code project with an Arduino sketch.
@@ -79,6 +80,7 @@ This extension provides several commands in the Command Palette (<kbd>F1</kbd> o
 | `arduino.disableTestingOpen` | Enable/disable automatic sending of a test message to the serial port for checking the open status. The default value is `false` (a test message will be sent). |
 | `arduino.skipHeaderProvider` | Enable/disable the extension providing completion items for headers. This functionality is included in newer versions of the C++ extension. The default value is `false`.|
 | `arduino.defaultBaudRate` | Default baud rate for the serial port monitor. The default value is 115200. Supported values are 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400 and 250000 |
+| `arduino.defaultTimestampFormat` | Default format of timestamp added before each line of Serial Monitor output. List of all possible formats: https://strftime.org. |
 | `arduino.disableIntelliSenseAutoGen` | When `true` vscode-arduino will not auto-generate an IntelliSense configuration (i.e. `.vscode/c_cpp_properties.json`) by analyzing Arduino's compiler output. |
 
 The following Visual Studio Code settings are available for the Arduino extension. These can be set in global user preferences <kbd>Ctrl</kbd> + <kbd>,</kbd> or workspace settings (`.vscode/settings.json`). The latter overrides the former.

--- a/package.json
+++ b/package.json
@@ -540,7 +540,7 @@
         "arduino.defaultTimestampFormat": {
           "type": "string",
           "default": "",
-          "description": "Format of timestamp added before each line. List of all possible formats: https://strftime.org"
+          "markdownDescription": "Format of timestamp printed before each line of Serial Monitor output. You can find list of all available placeholders [here](https://strftime.org)."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -531,6 +531,11 @@
           "type": "boolean",
           "default": false,
           "description": "When disabled vscode-arduino will not auto-generate an IntelliSense configuration (i.e. c_cpp_properties.json) by analyzing the compiler output."
+        },
+        "arduino.timestampFormat": {
+          "type": "string",
+          "default": "",
+          "description": "Format of timestamp added before each line. List of all possible formats: https://strftime.org"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "onCommand:arduino.selectSerialPort",
     "onCommand:arduino.selectSketch",
     "onCommand:arduino.changeBaudRate",
+    "onCommand:arduino.changeTimestampFormat",
     "onCommand:arduino.openSerialMonitor",
     "onCommand:arduino.sendMessageToSerialPort",
     "onCommand:arduino.closeSerialMonitor",
@@ -127,6 +128,10 @@
       {
         "command": "arduino.changeBaudRate",
         "title": "Arduino: Change Baud Rate"
+      },
+      {
+        "command": "arduino.changeTimestampFormat",
+        "title": "Arduino: Change Timestamp Format"
       },
       {
         "command": "arduino.openSerialMonitor",
@@ -532,7 +537,7 @@
           "default": false,
           "description": "When disabled vscode-arduino will not auto-generate an IntelliSense configuration (i.e. c_cpp_properties.json) by analyzing the compiler output."
         },
-        "arduino.timestampFormat": {
+        "arduino.defaultTimestampFormat": {
           "type": "string",
           "default": "",
           "description": "Format of timestamp added before each line. List of all possible formats: https://strftime.org"

--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -22,6 +22,7 @@ export interface IArduinoSettings {
     defaultBaudRate: number;
     preferences: Map<string, string>;
     useArduinoCli: boolean;
+    defaultTimestampFormat: string;
     reloadPreferences(): void;
 }
 
@@ -40,6 +41,8 @@ export class ArduinoSettings implements IArduinoSettings {
 
     private _useArduinoCli: boolean;
 
+    private _defaultTimestampFormat: string;
+
     public constructor() {
     }
 
@@ -49,6 +52,7 @@ export class ArduinoSettings implements IArduinoSettings {
         this._useArduinoCli = VscodeSettings.getInstance().useArduinoCli;
         await this.tryResolveArduinoPath();
         await this.tryGetDefaultBaudRate();
+        await this.tryGetDefaultTimestampFormat();
         if (platform === "win32") {
             await this.updateWindowsPath();
             if (this._commandPath === "") {
@@ -161,6 +165,10 @@ export class ArduinoSettings implements IArduinoSettings {
         return this._defaultBaudRate;
     }
 
+    public get defaultTimestampFormat() {
+        return this._defaultTimestampFormat;
+    }
+
     public reloadPreferences() {
         this._preferences = util.parseConfigFile(this.preferencePath);
         if (this.preferences.get("sketchbook.path")) {
@@ -232,6 +240,15 @@ export class ArduinoSettings implements IArduinoSettings {
             this._defaultBaudRate = 0;
         } else {
             this._defaultBaudRate = configValue;
+        }
+    }
+
+    private async tryGetDefaultTimestampFormat(): Promise<void> {
+        const configValue = VscodeSettings.getInstance().defaultTimestampFormat;
+        if (!configValue) {
+            this._defaultTimestampFormat = "";
+        } else {
+            this._defaultTimestampFormat = configValue;
         }
     }
 }

--- a/src/arduino/vscodeSettings.ts
+++ b/src/arduino/vscodeSettings.ts
@@ -19,6 +19,7 @@ const configKeys = {
     DEFAULT_BAUD_RATE: "arduino.defaultBaudRate",
     USE_ARDUINO_CLI: "arduino.useArduinoCli",
     DISABLE_INTELLISENSE_AUTO_GEN: "arduino.disableIntelliSenseAutoGen",
+    TIMESTAMP_FORMAT: "arduino.timestampFormat",
 };
 
 export interface IVscodeSettings {
@@ -35,6 +36,7 @@ export interface IVscodeSettings {
     defaultBaudRate: number;
     useArduinoCli: boolean;
     disableIntelliSenseAutoGen: boolean;
+    defaultTimestampFormat: string;
     updateAdditionalUrls(urls: string[]): void;
 }
 
@@ -116,6 +118,10 @@ export class VscodeSettings implements IVscodeSettings {
 
     public get disableIntelliSenseAutoGen(): boolean {
         return this.getConfigValue<boolean>(configKeys.DISABLE_INTELLISENSE_AUTO_GEN);
+    }
+
+    public get defaultTimestampFormat(): string {
+        return this.getConfigValue<string>(configKeys.TIMESTAMP_FORMAT);
     }
 
     public async updateAdditionalUrls(value) {

--- a/src/arduino/vscodeSettings.ts
+++ b/src/arduino/vscodeSettings.ts
@@ -19,7 +19,7 @@ const configKeys = {
     DEFAULT_BAUD_RATE: "arduino.defaultBaudRate",
     USE_ARDUINO_CLI: "arduino.useArduinoCli",
     DISABLE_INTELLISENSE_AUTO_GEN: "arduino.disableIntelliSenseAutoGen",
-    TIMESTAMP_FORMAT: "arduino.timestampFormat",
+    DEFAULT_TIMESTAMP_FORMAT: "arduino.defaultTimestampFormat",
 };
 
 export interface IVscodeSettings {
@@ -121,7 +121,7 @@ export class VscodeSettings implements IVscodeSettings {
     }
 
     public get defaultTimestampFormat(): string {
-        return this.getConfigValue<string>(configKeys.TIMESTAMP_FORMAT);
+        return this.getConfigValue<string>(configKeys.DEFAULT_TIMESTAMP_FORMAT);
     }
 
     public async updateAdditionalUrls(value) {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -47,4 +47,5 @@ export const statusBarPriority = {
     ENDING: 70,
     SKETCH: 80,
     PROGRAMMER: 90,
+    TIMESTAMP_FORMAT: 100,
 };

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -43,9 +43,9 @@ export const statusBarPriority = {
     PORT: 20,
     OPEN_PORT: 30,
     BAUD_RATE: 40,
+    TIMESTAMP_FORMAT: 50,
     BOARD: 60,
     ENDING: 70,
     SKETCH: 80,
     PROGRAMMER: 90,
-    TIMESTAMP_FORMAT: 100,
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -284,6 +284,7 @@ export async function activate(context: vscode.ExtensionContext) {
     registerNonArduinoCommand("arduino.selectSerialPort", () => serialMonitor.selectSerialPort(null, null));
     registerNonArduinoCommand("arduino.openSerialMonitor", () => serialMonitor.openSerialMonitor());
     registerNonArduinoCommand("arduino.changeBaudRate", () => serialMonitor.changeBaudRate());
+    registerNonArduinoCommand("arduino.changeTimestampFormat", () => serialMonitor.changeTimestampFormat());
     registerNonArduinoCommand("arduino.sendMessageToSerialPort", () => serialMonitor.sendMessageToSerialPort());
     registerNonArduinoCommand("arduino.closeSerialMonitor", (port, showWarning = true) => serialMonitor.closeSerialMonitor(port, showWarning));
 

--- a/src/serialmonitor/serialMonitor.ts
+++ b/src/serialmonitor/serialMonitor.ts
@@ -232,6 +232,10 @@ export class SerialMonitor implements vscode.Disposable {
             Logger.warn("No timestamp format inputted, keeping previous timestamp format.");
             return;
         }
+        if (!this._serialPortCtrl) {
+            Logger.warn("Serial Monitor has not been started.");
+            return;
+        }
         await this._serialPortCtrl.changeTimestampFormat(timestampFormat);
         this._currentTimestampFormat = timestampFormat;
         this._timestampFormatStatusBar.tooltip = `Timestamp Format: "${timestampFormat}"`;

--- a/src/serialmonitor/serialMonitor.ts
+++ b/src/serialmonitor/serialMonitor.ts
@@ -232,6 +232,10 @@ export class SerialMonitor implements vscode.Disposable {
             Logger.warn("No timestamp format inputted, keeping previous timestamp format.");
             return;
         }
+        if (timestampFormat.indexOf("%") < 0) {
+            Logger.warn("Invalid timestamp format, keeping previous timestamp format.", { value: timestampFormat });
+            return;
+        }
         if (!this._serialPortCtrl) {
             Logger.warn("Serial Monitor has not been started.");
             return;

--- a/src/serialmonitor/serialMonitor.ts
+++ b/src/serialmonitor/serialMonitor.ts
@@ -72,6 +72,7 @@ export class SerialMonitor implements vscode.Disposable {
         this._outputChannel = vscode.window.createOutputChannel(SerialMonitor.SERIAL_MONITOR);
         this._bufferedOutputChannel = new BufferedOutputChannel(this._outputChannel.append, 300);
         this._currentBaudRate = defaultBaudRate;
+        this._timestampFormat = defaultTimestampFormat;
         this._portsStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, constants.statusBarPriority.PORT);
         this._portsStatusBar.command = "arduino.selectSerialPort";
         this._portsStatusBar.tooltip = "Select Serial Port";

--- a/src/serialmonitor/serialMonitor.ts
+++ b/src/serialmonitor/serialMonitor.ts
@@ -268,11 +268,13 @@ export class SerialMonitor implements vscode.Disposable {
             this._openPortStatusBar.text = `$(x)`;
             this._openPortStatusBar.tooltip = "Close Serial Monitor";
             this._baudRateStatusBar.show();
+            this._timestampFormatStatusBar.show();
         } else {
             this._openPortStatusBar.command = "arduino.openSerialMonitor";
             this._openPortStatusBar.text = `$(plug)`;
             this._openPortStatusBar.tooltip = "Open Serial Monitor";
             this._baudRateStatusBar.hide();
+            this._timestampFormatStatusBar.hide();
         }
 
     }

--- a/src/serialmonitor/serialMonitor.ts
+++ b/src/serialmonitor/serialMonitor.ts
@@ -94,8 +94,8 @@ export class SerialMonitor implements vscode.Disposable {
         this._timestampFormatStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right,
                                                                            constants.statusBarPriority.TIMESTAMP_FORMAT);
         this._timestampFormatStatusBar.command = "arduino.changeTimestampFormat";
-        this._timestampFormatStatusBar.tooltip = "Timestamp Format";
-        this._timestampFormatStatusBar.text = defaultTimestampFormat;
+        this._timestampFormatStatusBar.tooltip = `Timestamp Format: "${defaultTimestampFormat}"`;
+        this._timestampFormatStatusBar.text = `$(watch)`;
         this.updatePortListStatus();
 
         const dc = DeviceContext.getInstance();
@@ -230,7 +230,7 @@ export class SerialMonitor implements vscode.Disposable {
         const timestampFormat = await vscode.window.showInputBox();
         await this._serialPortCtrl.changeTimestampFormat(timestampFormat);
         this._currentTimestampFormat = timestampFormat;
-        this._timestampFormatStatusBar.text = timestampFormat;
+        this._timestampFormatStatusBar.tooltip = `Timestamp Format: "${timestampFormat}"`;
     }
 
     public async closeSerialMonitor(port: string, showWarning: boolean = true): Promise<boolean> {

--- a/src/serialmonitor/serialMonitor.ts
+++ b/src/serialmonitor/serialMonitor.ts
@@ -23,6 +23,8 @@ export class SerialMonitor implements vscode.Disposable {
 
     public static DEFAULT_BAUD_RATE: number = 115200;
 
+    public static DEFAULT_TIMESTAMP_FORMAT: string = "";
+
     public static listBaudRates(): number[] {
         return [300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 250000, 500000, 1000000, 2000000];
     }
@@ -52,12 +54,20 @@ export class SerialMonitor implements vscode.Disposable {
 
     private _bufferedOutputChannel: BufferedOutputChannel;
 
+    private _timestampFormat: string;
+
     public initialize() {
         let defaultBaudRate;
         if (ArduinoContext.arduinoApp && ArduinoContext.arduinoApp.settings && ArduinoContext.arduinoApp.settings.defaultBaudRate) {
             defaultBaudRate = ArduinoContext.arduinoApp.settings.defaultBaudRate;
         } else {
             defaultBaudRate = SerialMonitor.DEFAULT_BAUD_RATE;
+        }
+        let defaultTimestampFormat;
+        if (ArduinoContext.arduinoApp && ArduinoContext.arduinoApp.settings && ArduinoContext.arduinoApp.settings.defaultBaudRate) {
+            defaultTimestampFormat = ArduinoContext.arduinoApp.settings.defaultTimestampFormat;
+        } else {
+            defaultTimestampFormat = SerialMonitor.DEFAULT_TIMESTAMP_FORMAT;
         }
         this._outputChannel = vscode.window.createOutputChannel(SerialMonitor.SERIAL_MONITOR);
         this._bufferedOutputChannel = new BufferedOutputChannel(this._outputChannel.append, 300);
@@ -154,6 +164,7 @@ export class SerialMonitor implements vscode.Disposable {
             this._serialPortCtrl = new SerialPortCtrl(
                 this._currentPort,
                 this._currentBaudRate,
+                this._timestampFormat,
                 this._bufferedOutputChannel,
                 this._outputChannel.show);
         }

--- a/src/serialmonitor/serialMonitor.ts
+++ b/src/serialmonitor/serialMonitor.ts
@@ -58,7 +58,6 @@ export class SerialMonitor implements vscode.Disposable {
 
     private _bufferedOutputChannel: BufferedOutputChannel;
 
-
     public initialize() {
         let defaultBaudRate;
         if (ArduinoContext.arduinoApp && ArduinoContext.arduinoApp.settings && ArduinoContext.arduinoApp.settings.defaultBaudRate) {
@@ -92,7 +91,8 @@ export class SerialMonitor implements vscode.Disposable {
         this._baudRateStatusBar.tooltip = "Baud Rate";
         this._baudRateStatusBar.text = defaultBaudRate.toString();
 
-        this._timestampFormatStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, constants.statusBarPriority.TIMESTAMP_FORMAT);
+        this._timestampFormatStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right,
+                                                                           constants.statusBarPriority.TIMESTAMP_FORMAT);
         this._timestampFormatStatusBar.command = "arduino.changeTimestampFormat";
         this._timestampFormatStatusBar.tooltip = "Timestamp Format";
         this._timestampFormatStatusBar.text = defaultTimestampFormat;

--- a/src/serialmonitor/serialMonitor.ts
+++ b/src/serialmonitor/serialMonitor.ts
@@ -228,6 +228,10 @@ export class SerialMonitor implements vscode.Disposable {
 
     public async changeTimestampFormat() {
         const timestampFormat = await vscode.window.showInputBox();
+        if (!timestampFormat) {
+            Logger.warn("No timestamp format inputted, keeping previous timestamp format.");
+            return;
+        }
         await this._serialPortCtrl.changeTimestampFormat(timestampFormat);
         this._currentTimestampFormat = timestampFormat;
         this._timestampFormatStatusBar.tooltip = `Timestamp Format: "${timestampFormat}"`;

--- a/src/serialmonitor/serialportctrl.ts
+++ b/src/serialmonitor/serialportctrl.ts
@@ -62,14 +62,17 @@ export class SerialPortCtrl {
   private _currentPort: string;
   private _currentBaudRate: number;
   private _currentSerialPort = null;
+  private _timestampFormat: string;
 
   public constructor(
       port: string,
       baudRate: number,
+      timestampFormat: string,
       private _bufferedOutputChannel: BufferedOutputChannel,
       private showOutputChannel: (preserveFocus?: boolean) => void) {
     this._currentBaudRate = baudRate;
     this._currentPort = port;
+    this._timestampFormat = timestampFormat;
   }
 
   /*
@@ -93,7 +96,7 @@ export class SerialPortCtrl {
 
     return new Promise((resolve, reject) => {
         this._child = spawn(SerialPortCtrl._serialCliPath,
-            ["open", this._currentPort, "-b", this._currentBaudRate.toString(), "--json"])
+            ["open", this._currentPort, "-b", this._currentBaudRate.toString(), "-t", this._timestampFormat, "--json"])
 
         this._child.on("error", (err) => {
             reject(err)

--- a/src/serialmonitor/serialportctrl.ts
+++ b/src/serialmonitor/serialportctrl.ts
@@ -62,7 +62,7 @@ export class SerialPortCtrl {
   private _currentPort: string;
   private _currentBaudRate: number;
   private _currentSerialPort = null;
-  private _timestampFormat: string;
+  private _currentTimestampFormat: string;
 
   public constructor(
       port: string,
@@ -72,7 +72,7 @@ export class SerialPortCtrl {
       private showOutputChannel: (preserveFocus?: boolean) => void) {
     this._currentBaudRate = baudRate;
     this._currentPort = port;
-    this._timestampFormat = timestampFormat;
+    this._currentTimestampFormat = timestampFormat;
   }
 
   /*
@@ -96,7 +96,7 @@ export class SerialPortCtrl {
 
     return new Promise((resolve, reject) => {
         this._child = spawn(SerialPortCtrl._serialCliPath,
-            ["open", this._currentPort, "-b", this._currentBaudRate.toString(), "-t", this._timestampFormat, "--json"])
+            ["open", this._currentPort, "-b", this._currentBaudRate.toString(), "-t", this._currentTimestampFormat, "--json"])
 
         this._child.on("error", (err) => {
             reject(err)
@@ -178,6 +178,24 @@ export class SerialPortCtrl {
   public changeBaudRate(newRate: number): Promise<void> {
     return new Promise((resolve, reject) => {
       this._currentBaudRate = newRate;
+      if (!this._child || !this.isActive) {
+        resolve();
+        return;
+      } else {
+            try {
+                this.stop();
+                this.open();
+                resolve();
+            } catch (error) {
+                reject(error);
+            }
+        }
+    });
+  }
+
+  public changeTimestampFormat(newTimestampFormat: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this._currentTimestampFormat = newTimestampFormat;
       if (!this._child || !this.isActive) {
         resolve();
         return;

--- a/src/serialmonitor/serialportctrl.ts
+++ b/src/serialmonitor/serialportctrl.ts
@@ -105,7 +105,7 @@ export class SerialPortCtrl {
         this._child.stdout.on("data", (data) => {
             if (this.isActive) {
                 const jsonObj = JSON.parse(data.toString())
-                this._bufferedOutputChannel.append(jsonObj["payload"] + "\n");
+                this._bufferedOutputChannel.append(jsonObj["timestamp"] + jsonObj["payload"] + "\n");
             }
         });
         // TODO: add message check to ensure _child spawned without errors

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -48,6 +48,7 @@ suite("Arduino: Extension Tests", () => {
                     "arduino.selectSerialPort",
                     "arduino.openSerialMonitor",
                     "arduino.changeBaudRate",
+                    "arduino.changeTimestampFormat",
                     "arduino.sendMessageToSerialPort",
                     "arduino.closeSerialMonitor",
                     "arduino.reloadExample",


### PR DESCRIPTION
Now you can print timestamp before each line of Serial Monitor output.
Format of timestamp can be changed using command "Arduino: Change Timestamp Format" (`arduino.changeTimestampFormat`).
You can find list of all available placeholders here: https://strftime.org.

---

Example ("Timestamp Format" set to `%H:%M:%S.%f -> `):
```
[Starting] Opening the serial port - /dev/cu.usbmodemFA131
17:13:18.016370 -> 0
17:13:19.019009 -> 1
17:13:20.018564 -> 2
17:13:21.018022 -> 3
17:13:22.017378 -> 4
17:13:23.020687 -> 5
...
```

---

This PR adresses these issues:
- https://github.com/microsoft/vscode-arduino/issues/936
- https://github.com/microsoft/vscode-arduino/issues/1088
- https://github.com/microsoft/vscode-arduino/issues/1214

**Warning!** This PR depends on https://github.com/microsoft/serial-monitor-cli/pull/10

---

@benmcmorran or @gcampbell-msft, please, could you review?