### PR TITLE
Re-enable VSIX signing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,8 +115,6 @@ steps:
       includeRootFolder: false
       archiveType: zip
       archiveFile: $(Build.StagingDirectory)\vscode-arduino.vsix
-  - script: python .\build\markExecutableFiles.py
-    displayName: Make serial monitor executable
   - task: MSBuild@1
     displayName: Sign VSIX
     inputs:
@@ -124,6 +122,12 @@ steps:
       msbuildArguments: /p:SignType=$(SignType)
     # MicroBuild signing will always fail on public PRs.
     condition: ne(variables['Build.Reason'], 'PullRequest')
+  # VSIX signing removes the executable attributes on files. Luckily, the
+  # signature only seems to be based on the content of the files, not the
+  # attributes, so we can safely go back and mark the serial monitor as
+  # executable without invalidating the signature.
+  - script: python .\build\markExecutableFiles.py
+    displayName: Make serial monitor executable
   - publish: $(Build.StagingDirectory)\vscode-arduino.vsix
     artifact: VS Code extension VSIX
     displayName: Publish extension VSIX as artifact

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,13 +123,7 @@ steps:
       solution: .\build\SignVsix.proj
       msbuildArguments: /p:SignType=$(SignType)
     # MicroBuild signing will always fail on public PRs.
-    # TODO: Signing the VSIX strips out the "main" executables for
-    # serial-monitor-cli on Mac and Linux, completely breaking serial
-    # functionality in the extension on these platforms. For now we disable VSIX
-    # signing because it's not a strict requirement, but we should investigate
-    # if we can either add extensions to these files or support extensionless
-    # files in VSIX signing.
-    condition: and(false, ne(variables['Build.Reason'], 'PullRequest'))
+    condition: ne(variables['Build.Reason'], 'PullRequest')
   - publish: $(Build.StagingDirectory)\vscode-arduino.vsix
     artifact: VS Code extension VSIX
     displayName: Publish extension VSIX as artifact

--- a/build/markExecutableFiles.py
+++ b/build/markExecutableFiles.py
@@ -6,8 +6,8 @@ input_archive_path = f"{staging_directory}/vscode-arduino.vsix"
 output_archive_path = f"{staging_directory}/vscode-arduino-out.vsix"
 
 filenames = [
-    "extension/out/serial-monitor-cli/darwin/main",
-    "extension/out/serial-monitor-cli/linux/main"
+    "extension/out/serial-monitor-cli/darwin/main.out",
+    "extension/out/serial-monitor-cli/linux/main.out"
 ]
 
 input_archive = zipfile.ZipFile(input_archive_path, 'r')

--- a/src/serialmonitor/serialportctrl.ts
+++ b/src/serialmonitor/serialportctrl.ts
@@ -52,7 +52,7 @@ export class SerialPortCtrl {
     if (os.platform() === "win32") {
         fileName = "main.exe"
     } else if (os.platform() === "linux" || os.platform() === "darwin") {
-        fileName = "main"
+        fileName = "main.out"
     }
     const deviceContext = DeviceContext.getInstance();
     return path.resolve(deviceContext.extensionPath, "out", "serial-monitor-cli", `${os.platform}`, fileName);


### PR DESCRIPTION
This is follow-up from a change in the serial-monitor-cli repo to add extensions to the Linux and Mac serial monitor executables.