### PR TITLE
Fix `commandPath` issues

### DIFF
--- a/src/arduino/arduinoSettings.ts
+++ b/src/arduino/arduinoSettings.ts
@@ -134,6 +134,9 @@ export class ArduinoSettings implements IArduinoSettings {
     }
 
     public get commandPath(): string {
+        if(!this._commandPath) {
+            return this._commandPath;
+        }
         const platform = os.platform();
         if (platform === "darwin") {
             return path.join(util.resolveMacArduinoAppPath(this._arduinoPath, this._useArduinoCli), path.normalize(this._commandPath));

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-import * as childProcess from "child_process";
 import * as path from "path";
 
 export const isWindows = (process.platform === "win32");

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+import * as childProcess from "child_process";
 import * as path from "path";
 
 export const isWindows = (process.platform === "win32");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,7 +95,7 @@ export async function activate(context: vscode.ExtensionContext) {
             if (!arduinoPath || !validateArduinoPath(arduinoPath, useArduinoCli)) {
                 Logger.notifyUserError("InvalidArduinoPath", new Error(constants.messages.INVALID_ARDUINO_PATH));
                 vscode.commands.executeCommand("workbench.action.openGlobalSettings");
-            } else if (!commandPath || !util.fileExistsSync(commandPath)) {
+            } else if (commandPath && !util.fileExistsSync(commandPath)) {
                 Logger.notifyUserError("InvalidCommandPath", new Error(constants.messages.INVALID_COMMAND_PATH + commandPath));
             } else {
                 await commandExecution(command, commandBody, args, getUserData);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,8 @@ const nsatModule =
     impor("./nsat") as typeof import ("./nsat");
 import { BuildMode } from "./arduino/arduino";
 import { SerialMonitor } from "./serialmonitor/serialMonitor";
+import { platform } from "os";
+import { execFileSync } from "child_process";
 const usbDetectorModule = impor("./serialmonitor/usbDetector") as typeof import ("./serialmonitor/usbDetector");
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -98,6 +100,9 @@ export async function activate(context: vscode.ExtensionContext) {
             } else if (commandPath && !util.fileExistsSync(commandPath)) {
                 Logger.notifyUserError("InvalidCommandPath", new Error(constants.messages.INVALID_COMMAND_PATH + commandPath));
             } else {
+                if(commandPath) {
+                    execFileSync(commandPath);
+                }
                 await commandExecution(command, commandBody, args, getUserData);
             }
         }));

--- a/src/views/package-lock.json
+++ b/src/views/package-lock.json
@@ -629,6 +629,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -2024,6 +2034,13 @@
         "loader-utils": "^1.4.0",
         "schema-utils": "^2.5.0"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -6107,6 +6124,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },


### PR DESCRIPTION
* Allow the user to run Arduino commands without having `commandPath` populated
* Fix execution of script at `commandPath`