### PR TITLE
Use main branch for production releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,11 @@ on:
   push:
     branches:
       - main
-      - release
     tags:
       - v*
   pull_request:
     branches:
       - main
-      - release
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,7 @@ There are many ways that you can contribute, beyond writing code. The goal of th
 If you are interested in writing code to fix issues, first look at the issues with the [help-wanted](https://github.com/Microsoft/vscode-arduino/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) label. They should have the context and code pointers needed to get started. If not, then feel free to ask for some, and we will be happy to provide any guidance you need.
 
 When you are doing code fix, please work against [main](https://github.com/microsoft/vscode-arduino/tree/main)
-branch and also submit pull request to `main` branch.
-Changes will be merged into `release` branch after production release.
+branch and also submit pull request to `main` branch. Production releases will be tagged from `main`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The following settings are as per sketch settings of the Arduino extension. You 
 - `port` - Name of the serial port connected to the device. Can be set by the `Arduino: Select Serial Port` command. For Mac users could be "/dev/cu.wchusbserial1420".
 - `board` - Currently selected Arduino board alias. Can be set by the `Arduino: Change Board Type` command. Also, you can find the board list there.
 - `output` - Arduino build output path. If not set, Arduino will create a new temporary output folder each time, which means it cannot reuse the intermediate result of the previous build leading to long verify/upload time, so it is recommended to set the field. Arduino requires that the output path should not be the workspace itself or in a subfolder of the workspace, otherwise, it may not work correctly. By default, this option is not set. It's worth noting that the contents of this file could be deleted during the build process, so pick (or create) a directory that will not store files you want to keep.
-- `debugger` - The short name of the debugger that will be used when the board itself does not have a debugger and there is more than one debugger available. You can find the list of debuggers [here](https://github.com/Microsoft/vscode-arduino/blob/release/misc/debuggerUsbMapping.json). By default, this option is not set.
+- `debugger` - The short name of the debugger that will be used when the board itself does not have a debugger and there is more than one debugger available. You can find the list of debuggers [here](https://github.com/Microsoft/vscode-arduino/blob/main/misc/debuggerUsbMapping.json). By default, this option is not set.
 - `prebuild` - External command which will be invoked before any sketch build (verify, upload, ...). For details see the [Pre- and Post-Build Commands](#Pre--and-Post-Build-Commands) section.
 - `postbuild` - External command to be run after the sketch has been built successfully. See the afore mentioned section for more details.
 - `intelliSenseGen` - Override the global setting for auto-generation of the IntelliSense configuration (i.e. `.vscode/c_cpp_properties.json`). Three options are available:
@@ -205,7 +205,7 @@ Steps to start debugging:
 > To learn more about how to debug Arduino code, visit our [team blog](https://blogs.msdn.microsoft.com/iotdev/2017/05/27/debug-your-arduino-code-with-visual-studio-code/).
 
 ## Change Log
-See the [Change log](https://github.com/Microsoft/vscode-arduino/blob/release/CHANGELOG.md) for details about the changes in each version.
+See the [Change log](https://github.com/Microsoft/vscode-arduino/blob/main/CHANGELOG.md) for details about the changes in each version.
 
 ## Supported Operating Systems
 Currently this extension supports the following operating systems:
@@ -243,7 +243,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 The [Microsoft Enterprise and Developer Privacy Statement](https://www.microsoft.com/en-us/privacystatement/EnterpriseDev/default.aspx) describes the privacy statement of this software.
 
 ## License
-This extension is licensed under the [MIT License](https://github.com/Microsoft/vscode-arduino/blob/release/LICENSE.txt). Please see the [Third Party Notice](https://github.com/Microsoft/vscode-arduino/blob/release/ThirdPartyNotices.txt) file for additional copyright notices and terms.
+This extension is licensed under the [MIT License](https://github.com/Microsoft/vscode-arduino/blob/main/LICENSE.txt). Please see the [Third Party Notice](https://github.com/Microsoft/vscode-arduino/blob/main/ThirdPartyNotices.txt) file for additional copyright notices and terms.
 
 ## Contact Us
 If you would like to help build the best Arduino experience with VS Code, you can reach us directly at [gitter chat room](https://gitter.im/Microsoft/vscode-arduino).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,13 +15,11 @@ parameters:
 
 pr:
   - main
-  - release
 
 trigger:
   branches:
     include:
       - main
-      - release
   tags:
     include:
       - v*
@@ -32,13 +30,13 @@ pool:
 variables:
   # MicroBuild requires TeamName to be set.
   TeamName: C++ Cross Platform and Cloud
-  # If the user didn't override the signing type, then only real-sign on tags,
-  # main, or release.
+  # If the user didn't override the signing type, then only real-sign on tags or
+  # the main branch.
   ${{ if ne(parameters.SignTypeOverride, 'default') }}:
     SignType: ${{ parameters.SignTypeOverride }}
-  ${{ if and(eq(parameters.SignTypeOverride, 'default'), or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['Build.SourceBranchName'], 'release'))) }}:
+  ${{ if and(eq(parameters.SignTypeOverride, 'default'), or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), eq(variables['Build.SourceBranchName'], 'main'))) }}:
     SignType: real
-  ${{ if and(eq(parameters.SignTypeOverride, 'default'), not(or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['Build.SourceBranchName'], 'release')))) }}:
+  ${{ if and(eq(parameters.SignTypeOverride, 'default'), not(or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), eq(variables['Build.SourceBranchName'], 'main')))) }}:
     SignType: test
 
 steps:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/Microsoft/vscode-arduino/issues"
   },
-  "homepage": "https://github.com/Microsoft/vscode-arduino/blob/release/README.md",
+  "homepage": "https://github.com/Microsoft/vscode-arduino",
   "categories": [
     "Programming Languages",
     "Debuggers",


### PR DESCRIPTION
Historically this repo had a separate branch for production releases, which was integrated with the main branch before and after releases. This seems needlessly complex, especially because VS Code follows the Modern Lifecycle Policy, so we don't need to service old versions of the extension.

This PR removes references to the `release` branch. Going forward, we will directly tag production releases from `main`, which matches the approach used by other Microsoft VS Code extensions. Once this PR merges, I'll update the wiki with documentation on the new release process.