### PR TITLE
Support Remote Development Board Selection

### DIFF
--- a/src/arduino/arduinoContentProvider.ts
+++ b/src/arduino/arduinoContentProvider.ts
@@ -77,7 +77,7 @@ export class ArduinoContentProvider implements vscode.TextDocumentContentProvide
                     var backgroundcolor = styles.getPropertyValue('--background-color') || '#1e1e1e';
                     var color = styles.getPropertyValue('--color') || '#d4d4d4';
                     var theme = document.body.className || 'vscode-dark';
-                    var url = "${this._webserver.getEndpointUri(type)}?" +
+                    var url = "${(await vscode.env.asExternalUri(this._webserver.getEndpointUri(type))).toString()}?" +
                             "theme=" + encodeURIComponent(theme.trim()) +
                             "&backgroundcolor=" + encodeURIComponent(backgroundcolor.trim()) +
                             "&color=" + encodeURIComponent(color.trim());

--- a/src/arduino/localWebServer.ts
+++ b/src/arduino/localWebServer.ts
@@ -5,6 +5,7 @@ import * as bodyParser from "body-parser";
 import * as express from "express";
 import * as http from "http";
 import * as path from "path";
+import { Uri } from "vscode";
 
 export default class LocalWebServer {
     private app = express();
@@ -19,8 +20,9 @@ export default class LocalWebServer {
     public getServerUrl(): string {
         return `http://localhost:${this.server.address().port}`;
     }
-    public getEndpointUri(type: string): string {
-        return `http://localhost:${this.server.address().port}/${type}`;
+
+    public getEndpointUri(type: string): Uri {
+        return Uri.parse(`http://localhost:${this.server.address().port}/${type}`);
     }
 
     public addHandler(url: string, handler: (req, res) => void): void {


### PR DESCRIPTION
Currently, the port of the workspace extension on the remote host is not automatically forwarded in the local VS Code instance. This PR uses `vscode.env.asExternalUri` in `arduinoContentProvider` instead of `localhost`, so the port is automatically forwarded. This way, calls to the API don't fail from the local UI. To isolate the issue, I opened up the dev tools for VS Code and manually forwarded the port the Arduino extension was using for the web server. The board view showed up after forwarding, indicating it is not automatically forwarded.

[Microsoft Docs Reference](https://code.visualstudio.com/api/advanced-topics/remote-extensions#forwarding-localhost)
Fixes #1064 

# How I Tested:

## Host - Windows
- VS Code: 1.64.2
- Arduino v0.4.11 (Installed from Extension Marketplace)

## Remote - Raspberry Pi Running Latest Rasbian 64 OS
- VS Code: 1.64.2
- No Arduino Extension Installed
- C/C++ Extension v1.8.4 (Installed from Extension Marketplace)
- Node: 14.19.0
- NPM: 6.14.16

## Steps
1. Remote SSH into Pi and clone repository.
2. Run the build task manually using `gulp build`, as the `preLaunchTask` for `Launch Extension` throws an error for cannot find `gulp`.
3. Comment out the `preLaunchTask` for `Launch Extension`.
4. Run `Launch Extension`.
5. VS Code window should launch with the newly compiled Arduino extension. When checking the extension tab, the extension still shows as grayed out.
6. Open a `.ino` file to load the extension.
7. Try to select a board. Page should load.
8. Compare results to just installing the Arduino extension from Marketplace.