### PR TITLE
Fix Launch Extension gulp Not Found on Linux

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,12 @@
         "**/.git/objects/**": true,
         "**/out/*": true,
         "**/node_modules/**": true
+    },
+    "terminal.integrated.automationProfile.linux":  { 
+        "path": "${env:SHELL}",
+        "env": {
+            "HOME": "${env:HOME}",
+            "USER": "${env:USER}"
+        }
     }
 }


### PR DESCRIPTION
# Problem Description
When trying to execute the "Launch Extension" launch task on my Raspberry Pi running Raspberry Pi OS 64 bit while accessing the `microsoft/vscode-arduino` repository on my Raspberry Pi remotely, gulp is not able to be found despite being installed on my machine. I had originally tested running the shell in interactive mode, and this seemed to fix the issue, but I was worried about this fix not working on other shells. Additionally, causing the shell to default to bash despite user OS settings did not seem like an appropriate fix.

This change loads the user settings into the default Linux terminal, ensuring that packages installed using `npm i -g` are available via the user's path setting. Additionally, this should help `nvm` load the version of `node` specified by the user instead of whatever the latest stable version is.

# To Test
1. Clone this repo onto a Raspberry Pi (may be applicable to other Linux systems as well).
2. `nvm install node` to install latest stable version of node.
3. `nvm install lts/fermium` to install LTS version 14 of node.
4. `nvm use lts/fermium`
5. `npm i`
6. `npm i -g gulp`
7. Run `Launch Extension`

## Expected Behavior without Fix
`gulp` cannot be found by the launch task. If `gulp build` is run before then the `preLaunchTask` is commented out in `launch.json`, the script will error out, as version 17 of node will be used causing an error with `html-webpack` (an issue will be written up with references later).

## Expected Behavior with Fix
Task runs as expected in user's default terminal, and new VS Code window launches with the extension running. The Arduino extension MAY need to be loaded onto the host computer without uploading to Raspberry Pi if testing this code remotely to see the extension load in VS Code.

Fixes #1460
Same kind of fix could potentially be implemented for Mac to fix #1442, but this needs investigation.