### PR TITLE
Change link to list of all available placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This extension provides several commands in the Command Palette (<kbd>F1</kbd> o
 | `arduino.disableTestingOpen` | Enable/disable automatic sending of a test message to the serial port for checking the open status. The default value is `false` (a test message will be sent). |
 | `arduino.skipHeaderProvider` | Enable/disable the extension providing completion items for headers. This functionality is included in newer versions of the C++ extension. The default value is `false`.|
 | `arduino.defaultBaudRate` | Default baud rate for the serial port monitor. The default value is 115200. Supported values are 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400 and 250000 |
-| `arduino.defaultTimestampFormat` | Format of timestamp printed before each line of Serial Monitor output. You can find list of all available placeholders [here](https://strftime.org). |
+| `arduino.defaultTimestampFormat` | Format of timestamp printed before each line of Serial Monitor output. You can find list of all available placeholders [here](https://github.com/samsonjs/strftime#supported-specifiers). |
 | `arduino.disableIntelliSenseAutoGen` | When `true` vscode-arduino will not auto-generate an IntelliSense configuration (i.e. `.vscode/c_cpp_properties.json`) by analyzing Arduino's compiler output. |
 
 The following Visual Studio Code settings are available for the Arduino extension. These can be set in global user preferences <kbd>Ctrl</kbd> + <kbd>,</kbd> *or* <kbd>Cmd</kbd> + <kbd>,</kbd> or workspace settings (`.vscode/settings.json`). The latter overrides the former.

--- a/package.json
+++ b/package.json
@@ -540,7 +540,7 @@
         "arduino.defaultTimestampFormat": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Format of timestamp printed before each line of Serial Monitor output. You can find list of all available placeholders [here](https://strftime.org)."
+          "markdownDescription": "Format of timestamp printed before each line of Serial Monitor output. You can find list of all available placeholders [here](https://github.com/samsonjs/strftime#supported-specifiers)."
         }
       }
     },


### PR DESCRIPTION
This project recently moved (in https://github.com/microsoft/vscode-arduino/pull/1450) to a different serial port library that uses another library for the time handling than the previous one.
There are different placeholders for time specifiers, so I updated the link to the list of all available placeholders to the correct website.

> https://strftime.org –> https://github.com/samsonjs/strftime#supported-specifiers

---

This PR addresses this issue:
- https://github.com/microsoft/vscode-arduino/issues/1469

---

@benmcmorran or @gcampbell-msft, would you mind reviewing?