### PR TITLE
Don't use `*` activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "onCommand:arduino.upload",
     "onCommand:arduino.cliUpload",
     "onCommand:arduino.uploadUsingProgrammer",
-    "onCommand:arduiono.cliUploadUsingProgrammer",
+    "onCommand:arduino.cliUploadUsingProgrammer",
     "onCommand:arduino.rebuildIntelliSenseConfig",
     "onCommand:arduino.selectProgrammer",
     "onCommand:arduino.selectSerialPort",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "C++"
   ],
   "activationEvents": [
-    "*",
+    "onLanguage:cpp",
     "onCommand:arduino.verify",
     "onCommand:arduino.upload",
     "onCommand:arduino.cliUpload",

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -13,7 +13,9 @@ suite("Arduino: Commands Tests", () => {
        const extension = vscode.extensions.getExtension("vsciot-vscode.vscode-arduino");
        if (!extension.isActive) {
             extension.activate().then((api) => {
-                done();
+                // The extension waits 100ms before registering some commands,
+                // so add a longer delay here before running tests.
+                setTimeout(() => done(), 200);
             }, () => {
                 done("Failed to activate extension");
             });


### PR DESCRIPTION
Using the `*` activation event is not a best practise. Instead, it should use `onLanguage:cpp` or something similar.

I realized that in `onCommand:arduiono.cliUploadUsingProgrammer` is a typo so that's also fixed in this PR...

---

Related to
- https://github.com/microsoft/vscode-arduino/issues/1478