### PR TITLE
Fix line-oriented callbacks

### DIFF
--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -756,15 +756,18 @@ export class ArduinoApp {
         // Wrap line-oriented callbacks to accept arbitrary chunks of data.
         const wrapLineCallback = (callback: (line: string) => void) => {
             let buffer = "";
+            let startIndex = 0;
             return (data: string) => {
                 buffer += data;
-                for (;;) {
-                    const pos = buffer.indexOf(os.EOL);
+                while (true) {
+                    const pos = buffer.indexOf(os.EOL, startIndex);
                     if (pos < 0) {
+                        startIndex = buffer.length;
                         break;
                     }
                     const line = buffer.substring(0, pos + os.EOL.length);
                     buffer = buffer.substring(pos + os.EOL.length);
+                    startIndex = 0;
                     callback(line);
                 }
             };


### PR DESCRIPTION
stdoutcb/stderrcb assume that an input string is a single line, but in fact it can contain multiple lines, or even be a part of a line.

One of the consequence is that cocopa fails to parse compiler output when it contains long lines (#1275).

This patch fixes the issue by introducing a buffer to accumulate received data before passing them to callbacks.

Fixes #1275.