### PR TITLE
Fix library search result rendering

### DIFF
--- a/src/views/app/components/LibraryManager.tsx
+++ b/src/views/app/components/LibraryManager.tsx
@@ -137,6 +137,10 @@ class LibraryManager extends React.Component<ILibraryManagerProps, ILibraryManag
         const isOperating = !!this.props.installingLibraryName || !!this.props.uninstallingLibraryName;
 
         const itemRenderer = (index, key) => {
+            // On updating a list, ReactList can call itemRenderer with large indices.
+            if (index >= filteredLibraries.length) {
+                return null;
+            }
             return (<LibraryItemView key={filteredLibraries[index].name} library={filteredLibraries[index]} {...libraryItemProps}/>);
         };
         const itemSizeEstimator = (index, cache) => {


### PR DESCRIPTION
ReactList may call itemRenderer with an index larger than list length when the component is being updated. Failing to handle the case causes the rendering to break due to an unhandled exception.

For example, try searching for "audioq". Until one types "audio", search results are correctly narrowed, but typing the final letter "q" does not update the results to zero due to an unhandled exception.

This patch fixes the issue by handling out of band indices in itemRenderer.

Fixes #1109