### PR TITLE
Add items to the unbundled module to fix webpacking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16678,7 +16678,7 @@
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.50",
+        "es5-ext": "0.10.53",
         "type": "^1.0.1"
       }
     },
@@ -17344,7 +17344,7 @@
       "dev": true,
       "requires": {
         "d": "1",
-        "es5-ext": "^0.10.35",
+        "es5-ext": "0.10.53",
         "es6-symbol": "^3.1.1"
       }
     },
@@ -17365,7 +17365,7 @@
       "dev": true,
       "requires": {
         "d": "1",
-        "es5-ext": "^0.10.46",
+        "es5-ext": "0.10.53",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
@@ -17798,7 +17798,7 @@
       "dev": true,
       "requires": {
         "d": "1",
-        "es5-ext": "~0.10.14"
+        "es5-ext": "0.10.53"
       }
     },
     "eventemitter2": {
@@ -20586,7 +20586,7 @@
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "dev": true,
       "requires": {
-        "es5-ext": "~0.10.2"
+        "es5-ext": "0.10.53"
       }
     },
     "make-dir": {
@@ -20803,7 +20803,7 @@
       "dev": true,
       "requires": {
         "d": "^1.0.1",
-        "es5-ext": "^0.10.53",
+        "es5-ext": "0.10.53",
         "es6-weak-map": "^2.0.3",
         "event-emitter": "^0.3.5",
         "is-promise": "^2.2.2",
@@ -24153,7 +24153,7 @@
       "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
       "dev": true,
       "requires": {
-        "es5-ext": "~0.10.46",
+        "es5-ext": "0.10.53",
         "next-tick": "1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16678,7 +16678,7 @@
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.53",
+        "es5-ext": "^0.10.50",
         "type": "^1.0.1"
       }
     },
@@ -17344,7 +17344,7 @@
       "dev": true,
       "requires": {
         "d": "1",
-        "es5-ext": "0.10.53",
+        "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
     },
@@ -17365,7 +17365,7 @@
       "dev": true,
       "requires": {
         "d": "1",
-        "es5-ext": "0.10.53",
+        "es5-ext": "^0.10.46",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
@@ -17798,7 +17798,7 @@
       "dev": true,
       "requires": {
         "d": "1",
-        "es5-ext": "0.10.53"
+        "es5-ext": "~0.10.14"
       }
     },
     "eventemitter2": {
@@ -20586,7 +20586,7 @@
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.53"
+        "es5-ext": "~0.10.2"
       }
     },
     "make-dir": {
@@ -20803,7 +20803,7 @@
       "dev": true,
       "requires": {
         "d": "^1.0.1",
-        "es5-ext": "0.10.53",
+        "es5-ext": "^0.10.53",
         "es6-weak-map": "^2.0.3",
         "event-emitter": "^0.3.5",
         "is-promise": "^2.2.2",
@@ -24153,7 +24153,7 @@
       "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.53",
+        "es5-ext": "~0.10.46",
         "next-tick": "1"
       }
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,8 @@ function getEntry() {
   const mod = JSON.parse(npmListRes);
   const unbundledModule = ['impor', 'uuid',
   // usb-native modules can not be bundled
+  // added debug, ms, node-gyp-build, and node-addon-api as a workaround a break in packaging 
+  // that caused the extension to not work. 
   'usb-detection', '@serialport', 'bindings', 'serialport', 'debug', 'ms', 'node-gyp-build', 'node-addon-api'];
   
   for (const mod of unbundledModule) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ function getEntry() {
   const mod = JSON.parse(npmListRes);
   const unbundledModule = ['impor', 'uuid',
   // usb-native modules can not be bundled
-  'usb-detection', '@serialport', 'bindings', 'serialport'];
+  'usb-detection', '@serialport', 'bindings', 'serialport', 'debug', 'ms', 'node-gyp-build', 'node-addon-api'];
   
   for (const mod of unbundledModule) {
     const p = 'node_modules/' + mod;


### PR DESCRIPTION
This is a workaround to make sure the web-packing happens correctly so that the extension can be functional. 
The items added to the "unbundledModule" are packages that are used from the node-serialport package, and this ensures that they are included and not bundled. 

I have created a package locally using 'vsce package' in order to create a vsix and tested that the commands seem to work. I didn't test each command end to end, but commands exist and are able to be called. 