### PR TITLE
Fix incorrect loaded boards when platform name changes

### DIFF
--- a/src/arduino/boardManager.ts
+++ b/src/arduino/boardManager.ts
@@ -229,7 +229,7 @@ export class BoardManager {
                     // });
 
                     // Check if platform name is the same, if not, we should use the name from the latest version.
-                    if (addedPlatform.name != plat.name) {
+                    if (addedPlatform.name !== plat.name) {
                         addedPlatform.name = plat.name;
                     }
 

--- a/src/arduino/boardManager.ts
+++ b/src/arduino/boardManager.ts
@@ -227,13 +227,17 @@ export class BoardManager {
                     // addedPlatform.boards = util.union(addedPlatform.boards, plat.boards, (a, b) => {
                     //     return a.name === b.name;
                     // });
-                    if (addedPlatform.name === plat.name) {
-                        addedPlatform.versions.push(plat.version);
-                        // Check if this is the latest version. Platforms typically support more boards in later versions.
-                        addedPlatform.versions.sort(versionCompare);
-                        if (plat.version === addedPlatform.versions[addedPlatform.versions.length - 1]) {
-                            addedPlatform.boards = plat.boards;
-                        }
+
+                    // Check if platform name is the same, if not, we should use the name from the latest version.
+                    if (addedPlatform.name != plat.name) {
+                        addedPlatform.name = plat.name;
+                    }
+
+                    addedPlatform.versions.push(plat.version);
+                    // Check if this is the latest version. Platforms typically support more boards in later versions.
+                    addedPlatform.versions.sort(versionCompare);
+                    if (plat.version === addedPlatform.versions[addedPlatform.versions.length - 1]) {
+                        addedPlatform.boards = plat.boards;
                     }
                 } else {
                     plat.versions = [plat.version];


### PR DESCRIPTION
This PR fixes `Board Manager` showing less vesions than expected. It happens because platform name may change between releases and there's a condtion which skips any other than the first one added. To keep the same behaviour as Arduino IDE it will always keep the latest platform name as source of truth.

![Screen Shot 2022-06-07 at 16 41 04](https://user-images.githubusercontent.com/782854/172487069-6410e749-75d7-468b-ab6f-a7dc62e81c20.png)
![Screen Shot 2022-06-07 at 18 22 09](https://user-images.githubusercontent.com/782854/172487013-6af1f1e1-8c20-420b-8595-15071ac0eb4f.png)

Fixes #1511 