### PR TITLE
bugfix: validateArduinoPath for mac

### DIFF
--- a/src/common/sys/darwin.ts
+++ b/src/common/sys/darwin.ts
@@ -19,7 +19,7 @@ export function resolveArduinoPath(): string {
 }
 
 export function validateArduinoPath(arduinoPath: string, useArduinoCli = false): boolean {
-    return fileExistsSync(path.join(resolveMacArduinoAppPath(arduinoPath, useArduinoCli), useArduinoCli ? "arduino-cli" : "/Contents/MacOS/Arduino"));
+    return fileExistsSync(path.join(resolveMacArduinoAppPath(arduinoPath, useArduinoCli), useArduinoCli ? "arduino-cli" : "/Contents/MacOS/Arduino IDE"));
 }
 
 export function findFile(fileName: string, cwd: string): string {


### PR DESCRIPTION
Latest Arduino application (Mac) name is 'Arduino IDE' instead of 'Arduino'.