### PR TITLE
Remove deprecated AzureIoTHub library from tests

### DIFF
--- a/test/librarymanager.test.ts
+++ b/test/librarymanager.test.ts
@@ -71,15 +71,15 @@ suite("Arduino: Library Manager.", () => {
         this.timeout(3 * 60 * 1000);
         try {
             // Library Manager: Install extenal libarary.
-            ArduinoContext.arduinoApp.installLibrary("AzureIoTHub", "1.0.35", true).then((result) => {
+            ArduinoContext.arduinoApp.installLibrary("FastLED", "3.5.0", true).then((result) => {
                 // check if the installation succeeds or not
                 const arduinoSettings = ArduinoContext.arduinoApp.settings;
-                const libPath = Path.join(arduinoSettings.sketchbookPath, "libraries", "AzureIoTHub");
+                const libPath = Path.join(arduinoSettings.sketchbookPath, "libraries", "FastLED");
 
                 if (util.directoryExistsSync(libPath)) {
                     done();
                 } else {
-                    done(new Error("AzureIoTHub library install failure, can't find library path: " + libPath));
+                    done(new Error("FastLED library install failure, can't find library path: " + libPath));
                 }
             });
 

--- a/test/librarymanager.test.ts
+++ b/test/librarymanager.test.ts
@@ -94,10 +94,10 @@ suite("Arduino: Library Manager.", () => {
         try {
             // Library Manager: remove extenal libarary.
             const arduinoSettings = ArduinoContext.arduinoApp.settings;
-            const libPath = Path.join(arduinoSettings.sketchbookPath, "libraries", "AzureIoTHub");
+            const libPath = Path.join(arduinoSettings.sketchbookPath, "libraries", "FastLED");
 
             if (util.directoryExistsSync(libPath)) {
-                ArduinoContext.arduinoApp.uninstallLibrary("AzureIoTHub", libPath);
+                ArduinoContext.arduinoApp.uninstallLibrary("FastLED", libPath);
                 assert.equal(util.directoryExistsSync(libPath), false,
                  "Library path still exist after calling uninstall library,remove the library failure");
             }

--- a/test/programmermanager.test.ts
+++ b/test/programmermanager.test.ts
@@ -68,7 +68,8 @@ suite("Arduino: Programmer Manager.", () => {
         assert.equal(programmerManager.currentDisplayName, "arduino:jtag3isp");
     });
 
-    test("changing arduino.ino value should change programmer", (done) => {
+    test("changing arduino.ino value should change programmer", function(done) {
+        this.timeout(3 * 60 * 1000);
         DeviceContext.getInstance().programmer = programmers[0].name;
         setTimeout(() => {
             assert.equal(programmerManager.currentProgrammer, programmers[0].key);


### PR DESCRIPTION
AzureIoTHub was [removed from the official list of libraries shown in Arduino's Library Manager](https://github.com/arduino/library-registry/pull/1640/files) on August 3, 2022, and this extension's automated tests have been failing since then. This PR switches to testing against FastLED instead, a popular third-party library that's unlikely to vanish anytime soon.