### PR TITLE
Add platform-specific VSIX publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,12 +72,12 @@ jobs:
       - name: Check for linting errors
         run: gulp tslint
       - name: Build and pack extension
-        run: vsce package --out vscode-arduino.vsix
+        run: node build/package.js
       - name: Publish extension VSIX as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: VS Code extension VSIX (${{ matrix.os }})
-          path: vscode-arduino.vsix
+          name: VS Code extension VSIXes (${{ matrix.os }})
+          path: out/vsix
 
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -18,3 +18,7 @@ node_modules/**
 vendor/**
 azure-pipelines.yml
 build/**
+assets/platform/**
+
+# A platform-specific directory in assets/platform/ will be added to the end of
+# this file by the packaging script.

--- a/assets/platform/alpine-arm64/placeholder.txt
+++ b/assets/platform/alpine-arm64/placeholder.txt
@@ -1,0 +1,1 @@
+This is a placeholder file that should only be installed on alpine-arm64.

--- a/assets/platform/alpine-x64/placeholder.txt
+++ b/assets/platform/alpine-x64/placeholder.txt
@@ -1,0 +1,1 @@
+This is a placeholder file that should only be installed on alpine-x64.

--- a/assets/platform/darwin-arm64/placeholder.txt
+++ b/assets/platform/darwin-arm64/placeholder.txt
@@ -1,0 +1,1 @@
+This is a placeholder file that should only be installed on darwin-arm64.

--- a/assets/platform/darwin-x64/placeholder.txt
+++ b/assets/platform/darwin-x64/placeholder.txt
@@ -1,0 +1,1 @@
+This is a placeholder file that should only be installed on darwin-x64.

--- a/assets/platform/linux-arm64/placeholder.txt
+++ b/assets/platform/linux-arm64/placeholder.txt
@@ -1,0 +1,1 @@
+This is a placeholder file that should only be installed on linux-arm64.

--- a/assets/platform/linux-armhf/placeholder.txt
+++ b/assets/platform/linux-armhf/placeholder.txt
@@ -1,0 +1,1 @@
+This is a placeholder file that should only be installed on linux-armhf.

--- a/assets/platform/linux-x64/placeholder.txt
+++ b/assets/platform/linux-x64/placeholder.txt
@@ -1,0 +1,1 @@
+This is a placeholder file that should only be installed on linux-x64.

--- a/assets/platform/win32-arm64/placeholder.txt
+++ b/assets/platform/win32-arm64/placeholder.txt
@@ -1,0 +1,1 @@
+This is a placeholder file that should only be installed on win32-arm64.

--- a/assets/platform/win32-ia32/placeholder.txt
+++ b/assets/platform/win32-ia32/placeholder.txt
@@ -1,0 +1,1 @@
+This is a placeholder file that should only be installed on win32-ia32.

--- a/assets/platform/win32-x64/placeholder.txt
+++ b/assets/platform/win32-x64/placeholder.txt
@@ -1,0 +1,1 @@
+This is a placeholder file that should only be installed on win32-x64.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ steps:
     displayName: Use Node 16.x
     inputs:
       versionSpec: 16.x
-  - script: npm install --global gulp node-gyp vsce
+  - script: npm install --global gulp node-gyp @vscode/vsce
     displayName: Install global dependencies
   - script: npm install
     displayName: Install project dependencies
@@ -87,14 +87,14 @@ steps:
   # Pack the extension now even though it's unsigned so that we ignore files
   # from .vscodeignore. This will reduce load on the signing server later and
   # ensure we only attempt to sign shipping files.
-  - script: vsce package --out vscode-arduino.vsix
+  - script: node build/package.js
     displayName: Build and pack extension
 
-  # Extract the VSIX, sign what we can, then pack it back up and publish it.
+  # Extract the VSIXes, sign what we can, then pack it back up and publish it.
   - task: ExtractFiles@1
     displayName: Extract extension for signing
     inputs:
-      archiveFilePatterns: vscode-arduino.vsix
+      archiveFilePatterns: out\vsix\*.vsix
       destinationFolder: $(Build.StagingDirectory)\vscode-arduino
   - task: NuGetToolInstaller@1
     displayName: Install NuGet

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,10 @@ steps:
       msbuildArguments: /p:SignType=$(SignType)
     # MicroBuild signing will always fail on public PRs.
     condition: ne(variables['Build.Reason'], 'PullRequest')
-  - pwsh: Get-ChildItem -Directory $(Build.StagingDirectory)\vscode-arduino | Foreach-Object { 7z a ($_.FullName + ".vsix") ($_.FullName + "\*") -tzip }
+  - pwsh: |
+        Get-ChildItem -Directory $(Build.StagingDirectory)\vscode-arduino | Foreach-Object { 7z a ($_.FullName + ".vsix") ($_.FullName + "\*") -tzip }
+        New-Item -Path $(Build.StagingDirectory)\vscode-arduino\vsix -ItemType Directory
+        Get-Item $(Build.StagingDirectory)\vscode-arduino\*.vsix | Move-Item -Destination $(Build.StagingDirectory)\vscode-arduino\vsix
     displayName: Pack signed files
   - task: MSBuild@1
     displayName: Sign VSIXes
@@ -124,7 +127,7 @@ steps:
       msbuildArguments: /p:SignType=$(SignType)
     # MicroBuild signing will always fail on public PRs.
     condition: ne(variables['Build.Reason'], 'PullRequest')
-  - publish: $(Build.StagingDirectory)\vscode-arduino
+  - publish: $(Build.StagingDirectory)\vscode-arduino\vsix
     artifact: VS Code extension VSIXes
     displayName: Publish extension VSIXes as artifact
 
@@ -185,7 +188,7 @@ steps:
       action: create
       target: $(Build.SourceVersion)
       tagSource: auto
-      assets: $(Build.StagingDirectory)\vscode-arduino\*.vsix
+      assets: $(Build.StagingDirectory)\vscode-arduino\vsix\*.vsix
       isPreRelease: $[contains(variables['Build.SourceBranch'], '-rc')]
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,7 +98,7 @@ steps:
       Remove-Item $path
       Echo "##vso[task.prependpath]$Env:PROGRAMFILES\7-Zip\"
     displayName: Install 7zip
-  - pwsh: Get-ChildItem out\vsix | Foreach-Object { 7z e $_.FullName -o$(Build.StagingDirectory)\vscode-arduino\$_.BaseName }
+  - pwsh: Get-ChildItem out\vsix | Foreach-Object { 7z e $_.FullName -o$(Build.StagingDirectory)\vscode-arduino\$($_.BaseName) }
     displayName: Extract extension for signing
   - task: NuGetToolInstaller@1
     displayName: Install NuGet

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,7 +98,7 @@ steps:
       Remove-Item $path
       Echo "##vso[task.prependpath]$Env:PROGRAMFILES\7-Zip\"
     displayName: Install 7zip
-  - pwsh: Get-ChildItem out\vsix | Foreach-Object { 7z e $_.FullName -o$(Build.StagingDirectory)\vscode-arduino\$($_.BaseName) }
+  - pwsh: Get-ChildItem out\vsix | Foreach-Object { 7z x $_.FullName -o$(Build.StagingDirectory)\vscode-arduino\$($_.BaseName) }
     displayName: Extract extension for signing
   - task: NuGetToolInstaller@1
     displayName: Install NuGet

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,11 +91,8 @@ steps:
     displayName: Build and pack extension
 
   # Extract the VSIXes, sign what we can, then pack it back up and publish it.
-  - task: ExtractFiles@1
+  - pwsh: Get-ChildItem out\vsix | Foreach-Object { 7z e $_.FullName -o$(Build.StagingDirectory)\vscode-arduino\$_.BaseName }
     displayName: Extract extension for signing
-    inputs:
-      archiveFilePatterns: out\vsix\*.vsix
-      destinationFolder: $(Build.StagingDirectory)\vscode-arduino
   - task: NuGetToolInstaller@1
     displayName: Install NuGet
   - task: NuGetAuthenticate@0
@@ -111,23 +108,18 @@ steps:
       msbuildArguments: /p:SignType=$(SignType)
     # MicroBuild signing will always fail on public PRs.
     condition: ne(variables['Build.Reason'], 'PullRequest')
-  - task: ArchiveFiles@2
+  - pwsh: Get-ChildItem -Directory $(Build.StagingDirectory)\vscode-arduino | Foreach-Object { 7z a ($_.FullName + ".vsix") $_.FullName\* -tzip }
     displayName: Pack signed files
-    inputs:
-      rootFolderOrFile: $(Build.StagingDirectory)\vscode-arduino
-      includeRootFolder: false
-      archiveType: zip
-      archiveFile: $(Build.StagingDirectory)\vscode-arduino.vsix
   - task: MSBuild@1
-    displayName: Sign VSIX
+    displayName: Sign VSIXes
     inputs:
       solution: .\build\SignVsix.proj
       msbuildArguments: /p:SignType=$(SignType)
     # MicroBuild signing will always fail on public PRs.
     condition: ne(variables['Build.Reason'], 'PullRequest')
-  - publish: $(Build.StagingDirectory)\vscode-arduino.vsix
-    artifact: VS Code extension VSIX
-    displayName: Publish extension VSIX as artifact
+  - publish: $(Build.StagingDirectory)\vscode-arduino
+    artifact: VS Code extension VSIXes
+    displayName: Publish extension VSIXes as artifact
 
   # Install the Arduino IDE and run tests.
   - script: curl -LO https://downloads.arduino.cc/arduino-1.8.19-windows.zip
@@ -186,7 +178,7 @@ steps:
       action: create
       target: $(Build.SourceVersion)
       tagSource: auto
-      assets: $(Build.StagingDirectory)\vscode-arduino.vsix
+      assets: $(Build.StagingDirectory)\vscode-arduino\*.vsix
       isPreRelease: $[contains(variables['Build.SourceBranch'], '-rc')]
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,6 +96,7 @@ steps:
       Invoke-WebRequest https://www.7-zip.org/a/7z2201-x64.exe -OutFile $path
       Start-Process -FilePath $path -Args "/S" -Verb RunAs -Wait
       Remove-Item $path
+      Echo "##vso[task.prependpath]$Env:PROGRAMFILES\7-Zip\"
     displayName: Install 7zip
   - pwsh: Get-ChildItem out\vsix | Foreach-Object { 7z e $_.FullName -o$(Build.StagingDirectory)\vscode-arduino\$_.BaseName }
     displayName: Extract extension for signing

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,12 @@ steps:
     displayName: Build and pack extension
 
   # Extract the VSIXes, sign what we can, then pack it back up and publish it.
+  - pwsh: |
+      $path = Join-Path $Env:TEMP "7z-installer.exe"
+      Invoke-WebRequest https://www.7-zip.org/a/7z2201-x64.exe -OutFile $path
+      Start-Process -FilePath $path -Args "/S" -Verb RunAs -Wait
+      Remove-Item $path
+    displayName: Install 7zip
   - pwsh: Get-ChildItem out\vsix | Foreach-Object { 7z e $_.FullName -o$(Build.StagingDirectory)\vscode-arduino\$_.BaseName }
     displayName: Extract extension for signing
   - task: NuGetToolInstaller@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,7 @@ steps:
       msbuildArguments: /p:SignType=$(SignType)
     # MicroBuild signing will always fail on public PRs.
     condition: ne(variables['Build.Reason'], 'PullRequest')
-  - pwsh: Get-ChildItem -Directory $(Build.StagingDirectory)\vscode-arduino | Foreach-Object { 7z a ($_.FullName + ".vsix") $_.FullName\* -tzip }
+  - pwsh: Get-ChildItem -Directory $(Build.StagingDirectory)\vscode-arduino | Foreach-Object { 7z a ($_.FullName + ".vsix") ($_.FullName + "\*") -tzip }
     displayName: Pack signed files
   - task: MSBuild@1
     displayName: Sign VSIXes

--- a/build/SignFiles.proj
+++ b/build/SignFiles.proj
@@ -3,7 +3,7 @@
   <Import Project="packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" />
 
   <PropertyGroup>
-    <BaseOutputDirectory>$(BUILD_STAGINGDIRECTORY)\vscode-arduino\extension</BaseOutputDirectory>
+    <BaseOutputDirectory>$(BUILD_STAGINGDIRECTORY)\vscode-arduino</BaseOutputDirectory>
     <!-- These properties are required by MicroBuild, which only signs files that are under these paths -->
     <IntermediateOutputPath>$(BaseOutputDirectory)</IntermediateOutputPath>
     <OutDir>$(BaseOutputDirectory)</OutDir>

--- a/build/SignVsix.proj
+++ b/build/SignVsix.proj
@@ -3,7 +3,7 @@
   <Import Project="packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" />
 
   <PropertyGroup>
-    <BaseOutputDirectory>$(BUILD_STAGINGDIRECTORY)\vscode-arduino</BaseOutputDirectory>
+    <BaseOutputDirectory>$(BUILD_STAGINGDIRECTORY)\vscode-arduino\vsix</BaseOutputDirectory>
     <!-- These properties are required by MicroBuild, which only signs files that are under these paths -->
     <IntermediateOutputPath>$(BaseOutputDirectory)</IntermediateOutputPath>
     <OutDir>$(BaseOutputDirectory)</OutDir>

--- a/build/SignVsix.proj
+++ b/build/SignVsix.proj
@@ -3,14 +3,14 @@
   <Import Project="packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" />
 
   <PropertyGroup>
-    <BaseOutputDirectory>$(BUILD_STAGINGDIRECTORY)</BaseOutputDirectory>
+    <BaseOutputDirectory>$(BUILD_STAGINGDIRECTORY)\vscode-arduino</BaseOutputDirectory>
     <!-- These properties are required by MicroBuild, which only signs files that are under these paths -->
     <IntermediateOutputPath>$(BaseOutputDirectory)</IntermediateOutputPath>
     <OutDir>$(BaseOutputDirectory)</OutDir>
   </PropertyGroup>
 
   <ItemGroup>
-    <FilesToSign Include="$(OutDir)\vscode-arduino.vsix">
+    <FilesToSign Include="$(OutDir)\*.vsix">
       <Authenticode>VsixSHA2</Authenticode>
     </FilesToSign>
   </ItemGroup>

--- a/build/package.js
+++ b/build/package.js
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+
+const { execSync } = require("child_process");
+const { mkdirSync, readFileSync, writeFileSync } = require("fs");
+const { resolve } = require("path");
+const { argv } = require("process");
+
+const flags = argv.slice(2).join(" ");
+
+// Taken from https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions
+const platforms = [
+  "win32-x64",
+  "win32-ia32",
+  "win32-arm64",
+  "linux-x64",
+  "linux-arm64",
+  "linux-armhf",
+  "alpine-x64",
+  "alpine-arm64",
+  "darwin-x64",
+  "darwin-arm64",
+];
+
+// We include different files for each platform, so we need to build a custom
+// .vscodeignore file based on common file and platform-specific path.
+const ignoreFile = readFileSync(resolve(__dirname, "..", ".vscodeignore"), "utf8");
+const customIgnoreFilePath = resolve(__dirname, "..", "out", ".vscodeignore");
+
+execSync('npm run build', { cwd: resolve(__dirname, ".."), stdio: "inherit" });
+mkdirSync(resolve(__dirname, "..", "out", "vsix"), { recursive: true });
+for (const platform of platforms) {
+  writeFileSync(
+    customIgnoreFilePath,
+    ignoreFile + `!assets/platform/${platform}/**`
+  );
+  const command = `vsce package --target ${platform} --out out/vsix/vscode-arduino-${platform}.vsix ${flags}`;
+  execSync(command, {
+    cwd: resolve(__dirname, ".."),
+    stdio: "inherit",
+  });
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "vsciot-vscode",
   "preview": true,
   "engines": {
-    "vscode": "^1.56.0"
+    "vscode": "^1.61.0"
   },
   "icon": "images/arduino.png",
   "license": "SEE LICENSE IN LICENSE.txt",
@@ -595,7 +595,7 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "gulp build --mode=production",
+    "build": "gulp build --mode=production",
     "postinstall": "cd ./src/views && npm install",
     "test": "gulp test"
   },
@@ -669,5 +669,8 @@
     "node-sass": "^7.0.0",
     "es5-ext": "0.10.53",
     "string_decoder": "https://github.com/microsoft/vscode-arduino/releases/download/v0.4.12-rc2/string_decoder-10.0.0.tgz"
+  },
+  "vsce": {
+    "ignoreFile": "out/.vscodeignore"
   }
 }


### PR DESCRIPTION
This will set us up to bundle platform specific copies of `arduinio-cli` with the extension. I tried pushing [a test tag](https://github.com/microsoft/vscode-arduino/releases/tag/platform-specific-release-pipeline-test) to verify the GitHub publishing steps, and everything seems to work correctly, including signing and installation in VS Code.