### PR TITLE
Fix IntelliSense configuration for Arduino CLI

### DIFF
--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -656,7 +656,7 @@ export class ArduinoApp {
 
         // We always build verbosely but filter the output based on the settings
 
-        this._settings.useArduinoCli ? args.push("--verbose") : args.push("--verbose-build");
+        this._settings.useArduinoCli ? args.push("--verbose", "--no-color") : args.push("--verbose-build");
 
         if (verbose && !this._settings.useArduinoCli) {
             args.push("--verbose-upload");
@@ -757,16 +757,17 @@ export class ArduinoApp {
         const wrapLineCallback = (callback: (line: string) => void) => {
             let buffer = "";
             let startIndex = 0;
+            const eol = this.useArduinoCli() ? "\n" : os.EOL;
             return (data: string) => {
                 buffer += data;
                 while (true) {
-                    const pos = buffer.indexOf(os.EOL, startIndex);
+                    const pos = buffer.indexOf(eol, startIndex);
                     if (pos < 0) {
                         startIndex = buffer.length;
                         break;
                     }
-                    const line = buffer.substring(0, pos + os.EOL.length);
-                    buffer = buffer.substring(pos + os.EOL.length);
+                    const line = buffer.substring(0, pos + eol.length);
+                    buffer = buffer.substring(pos + eol.length);
                     startIndex = 0;
                     callback(line);
                 }

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -246,7 +246,11 @@ export function spawn(
         }
 
         child.on("error", (error) => reject({ error }));
-        child.on("exit", (code) => {
+
+        // It's important to use use the "close" event instead of "exit" here.
+        // There could still be buffered data in stdout or stderr when the
+        // process exits that we haven't received yet.
+        child.on("close", (code) => {
             if (code === 0) {
                 resolve({ code });
             } else {


### PR DESCRIPTION
Fixes a few issues when using Arduino CLI:

- Arduino CLI seems to always use LF newlines regardless of the operating system. We were looking for CRLF on Windows (Arduino IDE behavior) which meant the compile output parser never got any data.
- The Arduino CLI process can exit before all the output data has been received on stdout by VS Code. The data arrives quickly but we need to use the `close` event on the child process to be sure we don't start parsing until the streams are closed.
- (cosmetic) By default, Arduino CLI uses terminal escape sequences to color certain parts of the output. These look ugly in VS Code's output window, which is not a terminal emulator. Pass the `--no-color` option to leave them out, at least for compile. We likely need to pass this flag in other places as well, but I'm planning to leave that for a more significant refactor when support for Arduino IDE is dropped.