### PR TITLE
Show warning when no boards are installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - [Arduino CLI](https://arduino.github.io/arduino-cli/0.30/) version 0.30.0 is now bundled with the extension [#1584](https://github.com/microsoft/vscode-arduino/pull/1584). To use the bundled version of Arduino CLI, `arduino.useArduinoCli` should be `true`, and `arduino.path` and `arduino.commandPath` should be empty or unset. Additionally, prompts will appear to switch to the bundled version whenever the legacy Arduino IDE is used or manually specified Arduino tools cannot be found.
+- A warning will appear in the Board Configuration view when no boards are installed. This warning links to the Board Manager view to install boards. [#1592](https://github.com/microsoft/vscode-arduino/pull/1584)
 
 ### Changed
 

--- a/src/arduino/arduinoContentProvider.ts
+++ b/src/arduino/arduinoContentProvider.ts
@@ -41,6 +41,7 @@ export class ArduinoContentProvider implements vscode.TextDocumentContentProvide
         this.addHandlerWithLogger("load-configitems", "/api/configitems", async (req, res) => await this.getBoardConfig(req, res));
         this.addHandlerWithLogger("update-selectedboard", "/api/updateselectedboard", (req, res) => this.updateSelectedBoard(req, res), true);
         this.addHandlerWithLogger("update-config", "/api/updateconfig", async (req, res) => await this.updateConfig(req, res), true);
+        this.addHandlerWithLogger("run-command", "/api/runcommand", (req, res) => this.runCommand(req, res), true);
 
         // Arduino Examples TreeView
         this.addHandlerWithLogger("show-examplesview", "/examples", (req, res) => this.getHtmlView(req, res));
@@ -166,6 +167,21 @@ export class ArduinoContentProvider implements vscode.TextDocumentContentProvide
                 });
             } catch (error) {
                 return res.status(500).send(`Cannot open the setting with error message "${error}"`);
+            }
+        }
+    }
+
+    public async runCommand(req, res) {
+        if (!req.body.command) {
+            return res.status(400).send("BAD Request! Missing { command } parameter!");
+        } else {
+            try {
+                await vscode.commands.executeCommand(req.body.command);
+                return res.json({
+                    status: "OK",
+                });
+            } catch (error) {
+                return res.status(500).send(`Cannot run command with error message "${error}"`);
             }
         }
     }

--- a/src/views/app/actions/api.ts
+++ b/src/views/app/actions/api.ts
@@ -43,6 +43,12 @@ export function openSettings(query) {
     }).then((response) => response.json());
 }
 
+export function runCommand(command) {
+    return postHTTP("/api/runcommand", {
+        command,
+    }).then((response) => response.json());
+}
+
 export function getLibraries(update) {
     return window.fetch(`/api/libraries?update=${update}`).then((response) => response.json());
 }

--- a/src/views/app/components/BoardConfig.tsx
+++ b/src/views/app/components/BoardConfig.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { Grid, Row } from "react-bootstrap";
 import { connect } from "react-redux";
 import * as actions from "../actions";
+import * as API from "../actions/api";
 import BoardConfigItemView from "./BoardConfigItemView";
 import BoardSelector from "./BoardSelector";
 
@@ -41,20 +42,31 @@ class BoardConfig extends React.Component<IBoardConfigProps, React.Props<any>> {
     }
 
     public render() {
-        return (<div className="boardConfig">
-            <Grid fluid>
-                <Row key="board-selector">
-                    <BoardSelector installedBoards={this.props.installedBoards} loadConfigItems={this.props.loadConfigItems} />
-                </Row>
-                {
-                    this.props.configitems.map((configitem, index) => {
-                        return (<Row key={configitem.id}>
-                            <BoardConfigItemView configitem={configitem} />
-                        </Row>);
-                    })
-                }
-            </Grid>
-        </div>);
+        let installWarning;
+        if (this.props.installedBoards.length === 0) {
+            installWarning = (<div className="theme-bgcolor arduinomanager-toolbar">
+                No boards are installed. <a className="help-link"
+                    onClick={() => API.runCommand("arduino.showBoardManager")}>Install a board with the Boards Manager.</a>
+            </div>);
+        }
+        return (
+            <div>
+                {installWarning}
+                <div className="boardConfig">
+                    <Grid fluid>
+                        <Row key="board-selector">
+                            <BoardSelector installedBoards={this.props.installedBoards} loadConfigItems={this.props.loadConfigItems} />
+                        </Row>
+                        {
+                            this.props.configitems.map((configitem, index) => {
+                                return (<Row key={configitem.id}>
+                                    <BoardConfigItemView configitem={configitem} />
+                                </Row>);
+                            })
+                        }
+                    </Grid>
+                </div>
+            </div>);
     }
 }
 


### PR DESCRIPTION
Found this usability issue when testing the bundled Arduino CLI on a fresh machine. When the user first tries to verify or upload, an error will appear say that a board needs to be selected. However, when the statusbar item is clicked to select a board, the dropdown is empty. This is because Arduino CLI has no boards installed by default. This PR adds a link to the Boards Manager in this case so that the user can install the board package they need.