### PR TITLE
fix the error message to output the message, not the object

### DIFF
--- a/src/serialmonitor/serialMonitor.ts
+++ b/src/serialmonitor/serialMonitor.ts
@@ -147,7 +147,6 @@ export class SerialMonitor implements vscode.Disposable {
             if (err.message) {
                 vscode.window.showErrorMessage(`Error opening serial port: ${err.message}`);
             }
-            
         }
     }
 

--- a/src/serialmonitor/serialMonitor.ts
+++ b/src/serialmonitor/serialMonitor.ts
@@ -144,7 +144,10 @@ export class SerialMonitor implements vscode.Disposable {
             this.updatePortStatus(true);
         } catch (err) {
             Logger.warn("Serial Monitor failed to open");
-            vscode.window.showErrorMessage(`Error opening serial port: ${err.toString()}`);
+            if (err.message) {
+                vscode.window.showErrorMessage(`Error opening serial port: ${err.message}`);
+            }
+            
         }
     }
 


### PR DESCRIPTION
Fix the output message when trying to open a serial monitor that isn't plugged in.

Error: 
![image](https://user-images.githubusercontent.com/86264750/219444040-acde72d4-ded4-4ba7-98a1-8c3cb895c102.png)

Fixed: 
![image](https://user-images.githubusercontent.com/86264750/219444207-816eb4fe-21b0-4b89-b1bc-c943ec0825fa.png)
