### PR TITLE
Fix board and library updates for CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - When using the bundled Arduino CLI, the extension will no longer attempt to make the CLI executable if it is already executable. Additionally, any errors that occur while attempting to make the CLI executable are shown in a notification. [#1601](https://github.com/microsoft/vscode-arduino/pull/1601)
+- Refreshing the index in the board manager or library manager now works correctly with the Arduino CLI, and additional URLs from the `arduino.additionalUrls` setting are passed to the Arduino CLI. [#1611](https://github.com/microsoft/vscode-arduino/pull/1611)
 
 ## Version 0.5.0
 

--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as child_process from 'child_process';
+import * as child_process from "child_process";
 import * as fs from "fs";
 import * as glob from "glob";
 import * as os from "os";
@@ -878,7 +878,7 @@ export class ArduinoApp {
         const additionalUrls = this.getAdditionalUrls();
         return util.spawn(
             this._settings.commandPath,
-            args.concat(['--additional-urls', additionalUrls.join(',')]),
+            args.concat(["--additional-urls", additionalUrls.join(",")]),
             options,
             output);
     }

--- a/src/arduino/boardManager.ts
+++ b/src/arduino/boardManager.ts
@@ -47,7 +47,7 @@ export class BoardManager {
         this._platforms = [];
         this._installedPlatforms = [];
 
-        const additionalUrls = this.getAdditionalUrls();
+        const additionalUrls = this._arduinoApp.getAdditionalUrls();
         if (update) { // Update index files.
             await this.setPreferenceUrls(additionalUrls);
             await this._arduinoApp.initialize(true);
@@ -113,11 +113,11 @@ export class BoardManager {
     }
 
     public async updatePackageIndex(indexUri: string): Promise<boolean> {
-        let allUrls = this.getAdditionalUrls();
+        let allUrls = this._arduinoApp.getAdditionalUrls();
         if (!(allUrls.indexOf(indexUri) >= 0)) {
             allUrls = allUrls.concat(indexUri);
             VscodeSettings.getInstance().updateAdditionalUrls(allUrls);
-            await this._arduinoApp.setPref("boardsmanager.additional.urls", this.getAdditionalUrls().join(","));
+            await this._arduinoApp.setPref("boardsmanager.additional.urls", this._arduinoApp.getAdditionalUrls().join(","));
         }
         return true;
     }
@@ -525,17 +525,6 @@ export class BoardManager {
             return;
         }
         return normalizedUrl.pathname.substr(normalizedUrl.pathname.lastIndexOf("/") + 1);
-    }
-
-    private getAdditionalUrls(): string[] {
-        // For better compatibility, merge urls both in user settings and arduino IDE preferences.
-        const settingsUrls = VscodeSettings.getInstance().additionalUrls;
-        let preferencesUrls = [];
-        const preferences = this._settings.preferences;
-        if (preferences && preferences.has("boardsmanager.additional.urls")) {
-            preferencesUrls = util.toStringArray(preferences.get("boardsmanager.additional.urls"));
-        }
-        return util.union(settingsUrls, preferencesUrls);
     }
 
     private async setPreferenceUrls(additionalUrls: string[]) {


### PR DESCRIPTION
Previously, refreshing the board index or library index simply attempted to install a board or library named "dummy", which doesn't make any sense in the Arduino CLI. Additional URLs from `arduino.additionalUrls` were also only written to a settings file but not passed to the Arduino CLI, so it was difficult to install third party boards or libraries.

This PR changes that behavior to call `core update-index` or `lib update-index` as appropriate, and wraps calls to the CLI to always pass the `--additional-urls` flag.