### PR TITLE
Bump required Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ You can find the full list of issues on the [Issue Tracker](https://github.com/M
 Installation prerequisites:
 
 - [Git](https://git-scm.com/)
-- [Node.js](https://nodejs.org/) (>= 12.x)
+- [Node.js](https://nodejs.org/) (>= 14.14)
 - [Npm](https://www.npmjs.com/) (>= 6.x)
 
 To *run and develop*, do the following:


### PR DESCRIPTION
The function fs.rmSync was added in Node.js 14.14; earlier versions won't build vscode-arduino. I tested `npm install` with Node.js 14.14 and it succeeds.