### PR TITLE
Log arduino-cli build command when running in verbose mode

### DIFF
--- a/src/arduino/arduino.ts
+++ b/src/arduino/arduino.ts
@@ -876,9 +876,14 @@ export class ArduinoApp {
                   stderr?: (s: string) => void},
     ): Thenable<object> {
         const additionalUrls = this.getAdditionalUrls();
+        args = args.concat(["--additional-urls", additionalUrls.join(",")])
+        const verbose = VscodeSettings.getInstance().logLevel === constants.LogLevel.Verbose;
+        if(verbose) {
+            arduinoChannel.channel.appendLine([this._settings.commandPath, ...args].join(" "));
+        }
         return util.spawn(
             this._settings.commandPath,
-            args.concat(["--additional-urls", additionalUrls.join(",")]),
+            args,
             options,
             output);
     }


### PR DESCRIPTION
Example output:

```
c:\Users\carlp\Desktop\vscode-arduino\assets\platform\win32-x64\arduino-cli\arduino-cli.exe compile -b arduino:avr:mega:cpu=atmega2560 --verbose --no-color --build-path c:\Users\carlp\Desktop\ArduinoOutput c:\Users\carlp\Desktop\TriacDimmer\examples\basic_example\basic_example.ino --additional-urls
```